### PR TITLE
Allow extra properties in pipelines, with a test

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -689,6 +689,5 @@
         ]
       }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -19,11 +19,20 @@ const validate = (name) => {
 }
 
 describe('schema.json', function() {
+  it('should validate block steps', function () {
+    validate('block.yml')
+  })
   it('should validate command steps', function() {
     validate('command.yml')
   })
-  it('should validate block steps', function() {
-    validate('block.yml')
+  it('should validate env blocks', function () {
+    validate('env.yml')
+  })
+  it('should validate blocks with extra properties', function () {
+    validate('extra-properties.yml')
+  })
+  it('should validate step groups', function () {
+    validate('group.yml')
   })
   it('should validate trigger steps', function() {
     validate('trigger.yml')

--- a/test/valid-pipelines/extra-properties.yml
+++ b/test/valid-pipelines/extra-properties.yml
@@ -1,0 +1,6 @@
+test_label_property: &test_label_property
+  label: "Test"
+
+steps:
+  - command: test
+    <<: *test_label_property


### PR DESCRIPTION
Addresses https://github.com/buildkite/pipeline-schema/issues/3.

This PR does three things
1. Allow extra properties in pipelines, so that reusable anchors don't fail validation.
2. Add a test to verify this.
3. Alphasort the test set.  I realized when doing this that the existing tests weren't all being run, so I fixed that, too.