### PR TITLE
Add new properties from recent releases

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -74,7 +74,11 @@
                 {
                   "type": "object",
                   "properties": {
-                    "step": { "type": "string" }
+                    "step": { "type": "string" },
+                    "allow_failure": {
+                      "type": "boolean",
+                      "default": false
+                    }
                   },
                   "additionalProperties": false
                 }

--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,11 @@
         "description": "A string identifier",
         "examples": [ "an-id" ]
       },
+      "if": {
+        "type": "string",
+        "description": "A boolean expression that omits the step when false",
+        "examples": [ "build.message != 'skip me'", "build.branch == 'master'" ]
+      },
       "label": {
         "type": "string",
         "description": "The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.",
@@ -201,6 +206,9 @@
         "identifier": {
           "$ref": "#/definitions/commonOptions/identifier"
         },
+        "if": {
+          "$ref": "#/definitions/commonOptions/if"
+        },
         "label": {
           "$ref": "#/definitions/commonOptions/label"
         },
@@ -302,6 +310,9 @@
         },
         "identifier": {
           "$ref": "#/definitions/commonOptions/identifier"
+        },
+        "if": {
+          "$ref": "#/definitions/commonOptions/if"
         },
         "label": {
           "$ref": "#/definitions/commonOptions/label"
@@ -481,6 +492,9 @@
         "identifier": {
           "$ref": "#/definitions/commonOptions/identifier"
         },
+        "if": {
+          "$ref": "#/definitions/commonOptions/if"
+        },
         "type": {
           "type": "string",
           "enum": [ "wait", "waiter" ]
@@ -594,6 +608,9 @@
         },
         "identifier": {
           "$ref": "#/definitions/commonOptions/identifier"
+        },
+        "if": {
+          "$ref": "#/definitions/commonOptions/if"
         },
         "label": {
           "$ref": "#/definitions/commonOptions/label"

--- a/schema.json
+++ b/schema.json
@@ -57,6 +57,27 @@
           [ "feature/*", "chore/*" ]
         ]
       },
+      "dependsOn": {
+        "description": "The step keys for a step to depend on",
+        "anyOf": [
+          {"type": "string"},
+          {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {"type": "string"},
+                {
+                  "type": "object",
+                  "properties": {
+                    "step": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        ]
+      },
       "identifier": {
         "type": "string",
         "description": "A string identifier",
@@ -87,6 +108,9 @@
         },
         "branches": {
           "$ref": "#/definitions/commonOptions/branches"
+        },
+        "depends_on": {
+          "$ref": "#/definitions/commonOptions/dependsOn"
         },
         "fields": {
           "type": "array",
@@ -306,6 +330,9 @@
             "my-pipeline/deploy"
           ]
         },
+        "depends_on": {
+          "$ref": "#/definitions/commonOptions/dependsOn"
+        },
         "env": {
           "type": "object",
           "description": "Environment variables for this step",
@@ -497,6 +524,9 @@
           "description": "Continue to the next steps, even if the previous group of steps fail",
           "type": "boolean"
         },
+        "depends_on": {
+          "$ref": "#/definitions/commonOptions/dependsOn"
+        },
         "id": {
           "$ref": "#/definitions/commonOptions/identifier"
         },
@@ -616,6 +646,9 @@
             }
           },
           "additionalProperties": false
+        },
+        "depends_on": {
+          "$ref": "#/definitions/commonOptions/dependsOn"
         },
         "id": {
           "$ref": "#/definitions/commonOptions/identifier"

--- a/schema.json
+++ b/schema.json
@@ -67,6 +67,11 @@
         "description": "A boolean expression that omits the step when false",
         "examples": [ "build.message != 'skip me'", "build.branch == 'master'" ]
       },
+      "key": {
+        "type": "string",
+        "description": "A unique identifier for a step, must not resemble a UUID",
+        "examples": [ "deploy-staging", "test-integration" ]
+      },
       "label": {
         "type": "string",
         "description": "The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.",
@@ -209,6 +214,9 @@
         "if": {
           "$ref": "#/definitions/commonOptions/if"
         },
+        "key": {
+          "$ref": "#/definitions/commonOptions/key"
+        },
         "label": {
           "$ref": "#/definitions/commonOptions/label"
         },
@@ -313,6 +321,9 @@
         },
         "if": {
           "$ref": "#/definitions/commonOptions/if"
+        },
+        "key": {
+          "$ref": "#/definitions/commonOptions/key"
         },
         "label": {
           "$ref": "#/definitions/commonOptions/label"
@@ -495,6 +506,9 @@
         "if": {
           "$ref": "#/definitions/commonOptions/if"
         },
+        "key": {
+          "$ref": "#/definitions/commonOptions/key"
+        },
         "type": {
           "type": "string",
           "enum": [ "wait", "waiter" ]
@@ -611,6 +625,9 @@
         },
         "if": {
           "$ref": "#/definitions/commonOptions/if"
+        },
+        "key": {
+          "$ref": "#/definitions/commonOptions/key"
         },
         "label": {
           "$ref": "#/definitions/commonOptions/label"

--- a/schema.json
+++ b/schema.json
@@ -195,6 +195,11 @@
                       "What’s the code name for this release? :name_badge:"
                     ]
                   },
+                  "multiple": {
+                    "type": "boolean",
+                    "description": "Whether more than one option may be selected",
+                    "default": false
+                    },
                   "options": {
                     "type": "array",
                     "items": {

--- a/schema.json
+++ b/schema.json
@@ -17,6 +17,11 @@
   ],
   "definitions": {
     "commonOptions": {
+      "allowDependencyFailure": {
+        "type": "boolean",
+        "description": "Whether to proceed with this step and further steps if a step named in the depends_on attribute fails",
+        "default": false
+      },
       "automaticRetry": {
         "type": "object",
         "properties": {
@@ -102,6 +107,9 @@
     "blockStep": {
       "type": "object",
       "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+        },
         "block": {
           "type": "string",
           "description": "The label of the block step"
@@ -285,6 +293,9 @@
             { "queue": "deploy" },
             { "ruby": "2*" }
           ]
+        },
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
         },
         "artifact_paths": {
           "anyOf": [
@@ -520,6 +531,9 @@
     "waitStep": {
       "type": "object",
       "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+        },
         "continue_on_failure": {
           "description": "Continue to the next steps, even if the previous group of steps fail",
           "type": "boolean"
@@ -575,6 +589,9 @@
     "triggerStep": {
       "type": "object",
       "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+        },
         "async": {
           "type": "boolean",
           "default": false,

--- a/test/valid-pipelines/block.yml
+++ b/test/valid-pipelines/block.yml
@@ -60,3 +60,6 @@ steps:
 
   - block: "A label"
     if: build.message !~ /skip tests/
+
+  - block: "A label"
+    key: important-step

--- a/test/valid-pipelines/block.yml
+++ b/test/valid-pipelines/block.yml
@@ -83,6 +83,11 @@ steps:
       - step: depend-on-me-2
 
   - block: "A label"
+    depends_on:
+      - step: depend-on-me
+        allow_failure: true
+
+  - block: "A label"
     allow_dependency_failure: true
 
   - block: "A label"

--- a/test/valid-pipelines/block.yml
+++ b/test/valid-pipelines/block.yml
@@ -57,3 +57,6 @@ steps:
         options:
           - label: "Select 2 Option 1"
             value: "select-2-option-1"
+
+  - block: "A label"
+    if: build.message !~ /skip tests/

--- a/test/valid-pipelines/block.yml
+++ b/test/valid-pipelines/block.yml
@@ -63,3 +63,21 @@ steps:
 
   - block: "A label"
     key: important-step
+
+  - block: "A label"
+    depends_on: depend-on-me
+
+  - block: "A label"
+    depends_on:
+      - depend-on-me-1
+      - depend-on-me-2
+
+  - block: "A label"
+    depends_on:
+      - step: depend-on-me-1
+      - step: depend-on-me-2
+
+  - block: "A label"
+    depends_on:
+      - depend-on-me-1
+      - step: depend-on-me-2

--- a/test/valid-pipelines/block.yml
+++ b/test/valid-pipelines/block.yml
@@ -81,3 +81,6 @@ steps:
     depends_on:
       - depend-on-me-1
       - step: depend-on-me-2
+
+  - block: "A label"
+    allow_dependency_failure: true

--- a/test/valid-pipelines/block.yml
+++ b/test/valid-pipelines/block.yml
@@ -84,3 +84,14 @@ steps:
 
   - block: "A label"
     allow_dependency_failure: true
+
+  - block: "A label"
+    fields:
+      - select: "Multiple fields"
+        key: "multiple-fields"
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1
+          - label: "Option 2"
+            value: option-2

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -137,3 +137,6 @@ steps:
     depends_on:
       - depend-on-me-1
       - step: depend-on-me-2
+
+  - command: test
+    allow_dependency_failure: true

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -116,3 +116,6 @@ steps:
 
   - command: test
     if: build.message !~ /skip tests/
+
+  - command: test
+    key: important-step

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -113,3 +113,6 @@ steps:
   - command: test
     soft_fail:
       - exit_status: "*"
+
+  - command: test
+    if: build.message !~ /skip tests/

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -139,4 +139,9 @@ steps:
       - step: depend-on-me-2
 
   - command: test
+    depends_on:
+      - step: depend-on-me
+        allow_failure: true
+
+  - command: test
     allow_dependency_failure: true

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -119,3 +119,21 @@ steps:
 
   - command: test
     key: important-step
+
+  - command: test
+    depends_on: depend-on-me
+
+  - command: test
+    depends_on:
+      - depend-on-me-1
+      - depend-on-me-2
+
+  - command: test
+    depends_on:
+      - step: depend-on-me-1
+      - step: depend-on-me-2
+
+  - command: test
+    depends_on:
+      - depend-on-me-1
+      - step: depend-on-me-2

--- a/test/valid-pipelines/trigger.yml
+++ b/test/valid-pipelines/trigger.yml
@@ -68,3 +68,6 @@ steps:
     depends_on:
       - depend-on-me-1
       - step: depend-on-me-2
+
+  - trigger: "a-slug"
+    allow_dependency_failure: true

--- a/test/valid-pipelines/trigger.yml
+++ b/test/valid-pipelines/trigger.yml
@@ -47,3 +47,6 @@ steps:
 
   - trigger: "a-slug"
     if: build.message !~ /skip tests/
+
+  - trigger: "a-slug"
+    key: important-step

--- a/test/valid-pipelines/trigger.yml
+++ b/test/valid-pipelines/trigger.yml
@@ -44,3 +44,6 @@ steps:
 
   - trigger: "a-slug"
     label: "Triggered label"
+
+  - trigger: "a-slug"
+    if: build.message !~ /skip tests/

--- a/test/valid-pipelines/trigger.yml
+++ b/test/valid-pipelines/trigger.yml
@@ -50,3 +50,21 @@ steps:
 
   - trigger: "a-slug"
     key: important-step
+
+  - trigger: "a-slug"
+    depends_on: depend-on-me
+
+  - trigger: "a-slug"
+    depends_on:
+      - depend-on-me-1
+      - depend-on-me-2
+
+  - trigger: "a-slug"
+    depends_on:
+      - step: depend-on-me-1
+      - step: depend-on-me-2
+
+  - trigger: "a-slug"
+    depends_on:
+      - depend-on-me-1
+      - step: depend-on-me-2

--- a/test/valid-pipelines/trigger.yml
+++ b/test/valid-pipelines/trigger.yml
@@ -70,4 +70,9 @@ steps:
       - step: depend-on-me-2
 
   - trigger: "a-slug"
+    depends_on:
+      - step: depend-on-me
+        allow_failure: true
+
+  - trigger: "a-slug"
     allow_dependency_failure: true

--- a/test/valid-pipelines/wait.yml
+++ b/test/valid-pipelines/wait.yml
@@ -52,3 +52,6 @@ steps:
     depends_on:
       - depend-on-me-1
       - step: depend-on-me-2
+
+  - type: waiter
+    allow_dependency_failure: true

--- a/test/valid-pipelines/wait.yml
+++ b/test/valid-pipelines/wait.yml
@@ -31,3 +31,6 @@ steps:
 
   - type: waiter
     if: build.message !~ /skip tests/
+
+  - type: waiter
+    key: important-step

--- a/test/valid-pipelines/wait.yml
+++ b/test/valid-pipelines/wait.yml
@@ -28,3 +28,6 @@ steps:
 
   - type: "waiter"
     identifier: "an-id"
+
+  - type: waiter
+    if: build.message !~ /skip tests/

--- a/test/valid-pipelines/wait.yml
+++ b/test/valid-pipelines/wait.yml
@@ -54,4 +54,9 @@ steps:
       - step: depend-on-me-2
 
   - type: waiter
+    depends_on:
+      - step: depend-on-me
+        allow_failure: true
+
+  - type: waiter
     allow_dependency_failure: true

--- a/test/valid-pipelines/wait.yml
+++ b/test/valid-pipelines/wait.yml
@@ -34,3 +34,21 @@ steps:
 
   - type: waiter
     key: important-step
+
+  - type: waiter
+    depends_on: depend-on-me
+
+  - type: waiter
+    depends_on:
+      - depend-on-me-1
+      - depend-on-me-2
+
+  - type: waiter
+    depends_on:
+      - step: depend-on-me-1
+      - step: depend-on-me-2
+
+  - type: waiter
+    depends_on:
+      - depend-on-me-1
+      - step: depend-on-me-2


### PR DESCRIPTION
Hey! I've added a few properties introduced in recent releases, going off the docs and changelog.

* `if`, `key`, `depends_on` and `allow_dependency_failure` for all the basic steps (Command, Block, Wait, Trigger)
* `multiple` for Block steps using select fields

Some of these changes should probably be applied to "groupStep" definition as well, if you have any guidance there.

I haven't added the Input step either, it seems to be new and I'm not sure how finalised it is.

Cheers! :shipit: