### PR TITLE
Adds $ prefix to ref in commands

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -334,7 +334,7 @@
         },
         "commands": {
           "description": "The commands to run on the agent",
-          "ref": "#/definitions/commandStep/properties/command"
+          "$ref": "#/definitions/commandStep/properties/command"
         },
         "concurrency": {
           "type": "integer",


### PR DESCRIPTION
This was the one spot in the schema that was missing a $ prefix before a ref key.