### PR TITLE
Add blocked_state definition to blockStep

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -118,6 +118,11 @@
           "type": "string",
           "description": "The label of the block step"
         },
+        "blocked_state": {
+          "type": "string",
+          "description": "The state that the build is set to when the build is blocked by this block step",
+          "enum": [ "passed", "failed", "running" ]
+        },
         "branches": {
           "$ref": "#/definitions/commonOptions/branches"
         },


### PR DESCRIPTION
Adds `blocked_state` according to block step attributes documentation: https://buildkite.com/docs/pipelines/block-step#block-step-attributes