### PR TITLE
Add `depends_on` and `key` to group step definitions

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1089,7 +1089,10 @@
               { "$ref": "#/definitions/commandStep" },
               { "$ref": "#/definitions/nestedCommandStep" },
               { "$ref": "#/definitions/triggerStep" },
-              { "$ref": "#/definitions/nestedTriggerStep" }
+              { "$ref": "#/definitions/nestedTriggerStep" },
+              { "$ref": "#/definitions/stringWaitStep" },
+              { "$ref": "#/definitions/waitStep" },
+              { "$ref": "#/definitions/nestedWaitStep" }    
             ]
           },
           "minSize": 1

--- a/schema.json
+++ b/schema.json
@@ -1057,16 +1057,22 @@
     },
     "groupStep": {
       "properties": {
+        "depends_on": {
+          "$ref": "#/definitions/commonOptions/dependsOn"
+        },
+        "group": {
+          "type": "string",
+          "description": "The name to give to this group of steps",
+          "examples": [ "Tests" ]
+        },
         "id": {
           "$ref": "#/definitions/commonOptions/identifier"
         },
         "identifier": {
           "$ref": "#/definitions/commonOptions/identifier"
         },
-        "group": {
-          "type": "string",
-          "description": "The name to give to this group of steps",
-          "examples": [ "Tests" ]
+        "key": {
+          "$ref": "#/definitions/commonOptions/key"
         },
         "label": {
           "$ref": "#/definitions/groupStep/properties/group"

--- a/test/valid-pipelines/group.yml
+++ b/test/valid-pipelines/group.yml
@@ -26,3 +26,13 @@ steps:
     name: "Tests"
     steps:
       - command: test
+
+  - group: "Tests"
+    depends_on: "an-id"
+    steps:
+      - command: test
+
+  - group: "Tests"
+    key: "a-key"
+    steps:
+      - command: test

--- a/test/valid-pipelines/group.yml
+++ b/test/valid-pipelines/group.yml
@@ -36,3 +36,10 @@ steps:
     key: "a-key"
     steps:
       - command: test
+
+  - group: "Tests"
+    steps:
+      - wait
+      - key: "waiter"
+        type: "wait"
+      - wait: { key: "waiter2", type: "wait" }


### PR DESCRIPTION
These options are valid and listed in the BuildKite documentation: https://buildkite.com/docs/pipelines/group-step#group-step-attributes

Fixes #27 