### PR TITLE
Fix invalid JSON in schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -647,7 +647,7 @@
         },
         "concurrency_method": {
           "type": "string",
-          "enum": ["ordered", "eager"]
+          "enum": ["ordered", "eager"],
           "description": "Control command order, allowed values are 'ordered' (default) and 'eager'.  If you use this attribute, you must also define concurrency_group and concurrency.",
           "examples": [
             "ordered"


### PR DESCRIPTION
Good day,

This PR adds a missing comma in the `schema.json` file that is currently causing it to be invalid JSON and consequently fixes the build in main.

Also thanks for maintaining this schema, we find it really helpful for testing our dynamic pipelines. Very much appreciated from a happy BuildKite user!