### PR TITLE
fix missing comma in `concurrency_method`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -647,7 +647,7 @@
         },
         "concurrency_method": {
           "type": "string",
-          "enum": ["ordered", "eager"]
+          "enum": ["ordered", "eager"],
           "description": "Control command order, allowed values are 'ordered' (default) and 'eager'.  If you use this attribute, you must also define concurrency_group and concurrency.",
           "examples": [
             "ordered"


### PR DESCRIPTION
fix missing comma in `concurrency_method`