### PR TITLE
update regexp used in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -704,7 +704,7 @@
                       "propertyNames": {
                         "type": "string",
                         "description": "Build Matrix dimension name",
-                        "pattern": "^[a-zA-Z0-9-_]+$"
+                        "pattern": "^[a-zA-Z0-9_]+$"
                       },
                       "additionalProperties": {
                         "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -283,7 +283,7 @@
                 "key": {
                   "type": "string",
                   "description": "The meta-data key that stores the field's input",
-                  "pattern": "^[a-zA-Z0-9-]+$",
+                  "pattern": "^[a-zA-Z0-9-_]+$",
                   "examples": [
                     "release-name"
                   ]
@@ -326,7 +326,7 @@
                 "key": {
                   "type": "string",
                   "description": "The meta-data key that stores the field's input",
-                  "pattern": "^[a-zA-Z0-9-]+$",
+                  "pattern": "^[a-zA-Z0-9-_]+$",
                   "examples": [
                     "release-stream"
                   ]
@@ -704,7 +704,7 @@
                       "propertyNames": {
                         "type": "string",
                         "description": "Build Matrix dimension name",
-                        "pattern": "^[a-zA-Z0-9_]+$"
+                        "pattern": "^[a-zA-Z0-9-_]+$"
                       },
                       "additionalProperties": {
                         "type": "array",

--- a/test/valid-pipelines/input.yml
+++ b/test/valid-pipelines/input.yml
@@ -100,3 +100,65 @@ steps:
             value: option-1
           - label: "Option 2"
             value: option-2
+
+# Key formats
+
+  - input: "Tests for key formatting"
+    fields:
+      # Text fields
+
+      - text: "Alphanumeric key, leading characters alpha"
+        key: aBc123
+      - text: "Alphanumeric key, leading characters numeric"
+        key: 123aBc
+
+      - text: "Underscored key"
+        key: underscored_key
+      - text: "Underscored key, leading underscore"
+        key: _underscored_key
+
+      - text: "Dasherized key"
+        key: dasherized-key
+      - text: "Dasherized key, leading dash"
+        key: -dasherized-key
+
+      # Select fields
+
+      - select: "Alphanumeric key, leading characters alpha"
+        key: aBc123
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1
+      - select: "Alphanumeric key, leading characters numeric"
+        key: 123aBc
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1
+
+      - select: "Underscored key"
+        key: underscored_key
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1
+      - select: "Underscored key, leading underscore"
+        key: _underscored_key
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1
+
+      - select: "Dasherized key"
+        key: dasherized-key
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1
+      - select: "Dasherized key, leading dash"
+        key: -dasherized-key
+        multiple: true
+        options:
+          - label: "Option 1"
+            value: option-1

--- a/test/valid-pipelines/matrix.yml
+++ b/test/valid-pipelines/matrix.yml
@@ -51,3 +51,21 @@ steps:
             shape:
               - triangle
               - hexagon
+
+# `setup` property name formats
+
+  - command: "Alphanumeric, leading numbers: {{matrix.123color}}"
+    label: "{{matrix.123color}}"
+    matrix:
+      setup:
+        123color:
+          - green
+          - blue
+
+  - command: "Underscored: {{matrix.color_123}}"
+    label: "{{matrix.color_123}}"
+    matrix:
+      setup:
+        color_123:
+          - green
+          - blue


### PR DESCRIPTION
Support both dashes and underscores as valid characters for keys for input and matrix steps.