### PR TITLE
Add support for explicit null in depends_on steps

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -90,6 +90,7 @@
       "dependsOn": {
         "description": "The step keys for a step to depend on",
         "anyOf": [
+          {"type": "null"},          
           {"type": "string"},
           {
             "type": "array",

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -153,6 +153,9 @@ steps:
         allow_failure: true
 
   - command: test
+    depends_on: ~
+
+  - command: test
     allow_dependency_failure: true
 
   - command: foo


### PR DESCRIPTION
Using `~` as an explicit "does not depend on anything" is part of the BuildKite documentation here: https://buildkite.com/docs/pipelines/dependencies#defining-explicit-dependencies

I'm also happy to include this for other step properties where it may make sense.