### PR TITLE
Add support for signal reason in retry rules

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -67,6 +67,18 @@
             "description": "The number of times this job can be retried",
             "minimum": 1,
             "maximum": 10
+          },
+          "signal_reason": {
+            "description": "The exit signal reason, if any, that may be retried",
+            "type": "string",
+            "enum": [
+              "*",
+              "none",
+              "agent_refused",
+              "agent_stop",
+              "cancel",
+              "process_run_error"
+            ]
           }
         },
         "additionalProperties": false

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -89,7 +89,10 @@ steps:
     retry:
       automatic:
         - exit_status: -1
+          signal_reason: none
         - exit_status: 255
+        - exit_status: 3
+          limit: 3
 
   - command: test
     retry:


### PR DESCRIPTION
Retry rules are evolving new ways to match failures which may be retried, starting with signal reason. This allows differentiating between an agent being stopped versus being lost in unknown ways, for example.

Fixes [PDP-199](https://linear.app/buildkite/issue/PDP-199/update-pipeline-schema).