### PR TITLE
Add support for signal in retry rules

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -68,6 +68,16 @@
             "minimum": 1,
             "maximum": 10
           },
+          "signal": {
+            "description": "The exit signal, if any, that may be retried",
+            "type": "string",
+            "examples": [
+              "*",
+              "none",
+              "SIGKILL",
+              "term"
+            ]
+          },
           "signal_reason": {
             "description": "The exit signal reason, if any, that may be retried",
             "type": "string",

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -90,6 +90,7 @@ steps:
       automatic:
         - exit_status: -1
           signal_reason: none
+        - signal: kill
         - exit_status: 255
         - exit_status: 3
           limit: 3


### PR DESCRIPTION
Retry rules are evolving new ways to match failures which may be retried. This introduces support for signal. This allows differentiating when an agent sends a signal to a job and the job doesn't handle it gracefully.

For example, this is a valid way to write a retry rule for targeting a job that failed to cancel gracefully within 10 seconds:

```yaml
- command: ...
  retry:
    automatic:
     signal_reason: cancel
     signal: kill
```

Related to [PDP-211](https://linear.app/buildkite/issue/PDP-211).