### PR TITLE
Correct the schema dialect declaration

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "JSON schema for Buildkite pipeline configuration files",
-  "$schema": "http://json-schema.org/draft-06/schema",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "fileMatch": [
     "buildkite.yml",
     "buildkite.yaml",


### PR DESCRIPTION
JSON Schema is specific about the schema dialect identifiers being exact strings, and some implementations respect or require this.

Correcting the "$schema" key will better guarantee that implementations evaluate the schema under the correct dialect and do not reject the schema as invalid.

(Found while testing the new ref resolution implementation being worked on in `python-jsonschema`.)