### PR TITLE
Add Soft Fail to Trigger Step Schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1189,6 +1189,9 @@
         },
         "skip": {
           "$ref": "#/definitions/commonOptions/skip"
+        },
+        "soft_fail": {
+          "$ref": "#/definitions/commonOptions/softFail"
         }
       },
       "additionalProperties": false

--- a/test/valid-pipelines/trigger.yml
+++ b/test/valid-pipelines/trigger.yml
@@ -82,3 +82,17 @@ steps:
 
   - trigger: "a-slug"
     skip: "reason for skipping"
+
+  - trigger: "a-slug"
+    soft_fail: true
+
+  - trigger: "a-slug"
+    soft_fail: false
+
+  - trigger: "a-slug"
+    soft_fail:
+      - exit_status: 1
+
+  - trigger: "a-slug"
+    soft_fail:
+      - exit_status: "*"


### PR DESCRIPTION
Buildkite [documentation for trigger step](https://buildkite.com/docs/pipelines/trigger-step) lists `soft_fail` as a valid optional attribute.

This PR updates schema to reflect `soft_fail` attribute in trigger step.

Validated via `docker-compose build && docker-compose run --rm tests`. Saw expected test behavior with and without changes in schema.