### PR TITLE
fix: Allow if and input in group steps

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1244,6 +1244,8 @@
               { "$ref": "#/definitions/nestedCommandStep" },
               { "$ref": "#/definitions/triggerStep" },
               { "$ref": "#/definitions/nestedTriggerStep" },
+              { "$ref": "#/definitions/inputStep" },
+              { "$ref": "#/definitions/nestedInputStep" },
               { "$ref": "#/definitions/stringWaitStep" },
               { "$ref": "#/definitions/waitStep" },
               { "$ref": "#/definitions/nestedWaitStep" }    

--- a/schema.json
+++ b/schema.json
@@ -1244,6 +1244,7 @@
               { "$ref": "#/definitions/nestedCommandStep" },
               { "$ref": "#/definitions/triggerStep" },
               { "$ref": "#/definitions/nestedTriggerStep" },
+              { "$ref": "#/definitions/stringInputStep" },
               { "$ref": "#/definitions/inputStep" },
               { "$ref": "#/definitions/nestedInputStep" },
               { "$ref": "#/definitions/stringWaitStep" },

--- a/schema.json
+++ b/schema.json
@@ -1221,6 +1221,9 @@
         "identifier": {
           "$ref": "#/definitions/commonOptions/identifier"
         },
+        "if": {
+          "$ref": "#/definitions/commonOptions/if"
+        },
         "key": {
           "$ref": "#/definitions/commonOptions/key"
         },

--- a/test/valid-pipelines/group.yml
+++ b/test/valid-pipelines/group.yml
@@ -43,3 +43,16 @@ steps:
       - key: "waiter"
         type: "wait"
       - wait: { key: "waiter2", type: "wait" }
+
+  - group: "Tests"
+    steps:
+      - input
+      - input: "A label"
+      - key: "input"
+        type: "input"
+      - input: { key: "input2", type: "input" }
+
+  - group: "Tests"
+    steps:
+      - command: test
+    if: build.message !~ /skip tests/


### PR DESCRIPTION
Fixes https://github.com/buildkite/pipeline-schema/issues/54 and https://github.com/buildkite/pipeline-schema/issues/57

I have no idea how to get this approved and merged [because there is no contribution documentation](https://github.com/buildkite/pipeline-schema/issues/58).

In the meantime... you can save:
https://raw.githubusercontent.com/Tyler-2/pipeline-schema/fix-if-and-input/schema.json
to a local place and then open up your VSCode or VSCodium settings and navigate to Settings, Extensions, YAML, Yaml: Schemas, "Edit in settings.json".

And then add something like:

```
    "yaml.schemas": {
        
        "/home/someuser/unnecessarydownloads/schema.json": "pipeline.yml"

    },
```

Which will tell the yaml language server to use that schema.json for files named pipeline.yml.