### PR TITLE
Add format as valid child to fields

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -117,7 +117,7 @@
       "dependsOn": {
         "description": "The step keys for a step to depend on",
         "anyOf": [
-          {"type": "null"},          
+          {"type": "null"},
           {"type": "string"},
           {
             "type": "array",
@@ -321,6 +321,13 @@
                   "description": "The explanatory text that is shown after the label",
                   "examples": [
                     "What’s the code name for this release? :name_badge:"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The format must be a regular expression implicitly anchored to the beginning and end of the input and is functionally equivalent to the HTML5 pattern attribute.  ",
+                  "examples": [
+                    "[0-9a-f]+"
                   ]
                 },
                 "required": {
@@ -1249,7 +1256,7 @@
               { "$ref": "#/definitions/nestedInputStep" },
               { "$ref": "#/definitions/stringWaitStep" },
               { "$ref": "#/definitions/waitStep" },
-              { "$ref": "#/definitions/nestedWaitStep" }    
+              { "$ref": "#/definitions/nestedWaitStep" }
             ]
           },
           "minSize": 1

--- a/schema.json
+++ b/schema.json
@@ -325,7 +325,8 @@
                 },
                 "format": {
                   "type": "string",
-                  "description": "The format must be a regular expression implicitly anchored to the beginning and end of the input and is functionally equivalent to the HTML5 pattern attribute.  ",
+                  "description": "The format must be a regular expression implicitly anchored to the beginning and end of the input and is functionally equivalent to the HTML5 pattern attribute.",
+                  "format": "regex",
                   "examples": [
                     "[0-9a-f]+"
                   ]

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "JSON schema for Buildkite pipeline configuration files",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "fileMatch": [
     "buildkite.yml",
     "buildkite.yaml",

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -9,7 +9,6 @@ const validate = (name) => {
   const pipeline = yaml.safeLoad(fs.readFileSync(`./valid-pipelines/${name}`, 'utf8'))
 
   const ajv = new Ajv({ allErrors: true })
-  ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
   var validate = ajv.compile(schema)
 
   var valid = validate(pipeline)

--- a/test/valid-pipelines/input.yml
+++ b/test/valid-pipelines/input.yml
@@ -1,6 +1,5 @@
 steps:
   # Different nesting formats
-
   - input
 
   - input: "A label"
@@ -17,7 +16,6 @@ steps:
         key: "field-1"
 
   # All the options
-
   - input: "A label"
 
   - input: "A label"
@@ -101,12 +99,24 @@ steps:
           - label: "Option 2"
             value: option-2
 
-# Key formats
+  # Text field formats
+  - input: "A label"
+    prompt: "A prompt"
+    fields:
+      - text: "Formatted field 1"
+        key: "formatted-field-1"
+        format: "\\d{4,4}"
+      - text: "Formatted field 2"
+        key: "formatted-field-2"
+        format: "[0-9]{3}"
+      - text: "Formatted field 3"
+        key: "formatted-field-3"
+        format: "[0-9a-f]+"
 
+  # Key formats
   - input: "Tests for key formatting"
     fields:
       # Text fields
-
       - text: "Alphanumeric key, leading characters alpha"
         key: aBc123
       - text: "Alphanumeric key, leading characters numeric"
@@ -123,7 +133,6 @@ steps:
         key: -dasherized-key
 
       # Select fields
-
       - select: "Alphanumeric key, leading characters alpha"
         key: aBc123
         multiple: true


### PR DESCRIPTION
This PR corrects the Schema which currently doesn't allow `fields` to have the property `format`. In your own documentation you write that `format` can be used for input validation. https://buildkite.com/docs/pipelines/input-step#input-validation

We have several pipelines that use the `format` property and they all work fine. The only problem we have is when we try to validate our pipelines against this JSON schema. 