### PR TITLE
Add a pattern matching for keys

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -163,6 +163,7 @@
       "key": {
         "type": "string",
         "description": "A unique identifier for a step, must not resemble a UUID",
+        "pattern": "^[a-zA-Z0-9-_:]+$",
         "examples": [ "deploy-staging", "test-integration" ]
       },
       "label": {


### PR DESCRIPTION
Add more validation for the key field to prevent this upload error:
<img width="1717" alt="image" src="https://github.com/buildkite/pipeline-schema/assets/2565652/bcb198df-aa70-4548-9089-ec9f35e3ccb3">
