### PR TITLE
Add signature_rejected signal_reason enum value

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -90,7 +90,8 @@
               "agent_refused",
               "agent_stop",
               "cancel",
-              "process_run_error"
+              "process_run_error",
+              "signature_rejected"
             ]
           }
         },


### PR DESCRIPTION
we added a new signal reason value, `signature_rejected`, as part of the signed pipelines work. this PR adds a new enum value to the json schema.