### PR TITLE
Add missing `skip` attribute to `groupStep`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1313,6 +1313,9 @@
     "notify": {
       "$ref": "#/definitions/commonOptions/buildNotify"
     },
+    "skip": {
+      "$ref": "#/definitions/commonOptions/skip"
+    },
     "steps": {
       "description": "A list of steps",
       "type": "array",


### PR DESCRIPTION
The `skip` attribute is [documented](https://buildkite.com/docs/pipelines/group-step#group-step-attributes) on for the group step, but is missing from the schema.

This adds it to match the online documentation.