### PR TITLE
Move `skip` attribute to `groupStep` from pipeline properties

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1274,6 +1274,9 @@
         "notify": {
           "$ref": "#/definitions/commonOptions/buildNotify"
         },
+        "skip": {
+          "$ref": "#/definitions/commonOptions/skip"
+        },
         "steps": {
           "type": "array",
           "description": "A list of steps",
@@ -1312,9 +1315,6 @@
     },
     "notify": {
       "$ref": "#/definitions/commonOptions/buildNotify"
-    },
-    "skip": {
-      "$ref": "#/definitions/commonOptions/skip"
     },
     "steps": {
       "description": "A list of steps",


### PR DESCRIPTION
In https://github.com/buildkite/pipeline-schema/pull/73, I accidentally added the `skip` attribute to the top level instead of the `groupStep`. This PR fixes that mistake.