### PR TITLE
A retry can be the string value of a boolean

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -969,7 +969,7 @@
               "anyOf": [
                 {
                   "type": ["boolean", "string"],
-                  "pattern": "^(true|false|yes|no)$"
+                  "pattern": "^(true|false)$"
                 },
                 {
                   "$ref": "#/definitions/commonOptions/automaticRetry"
@@ -994,20 +994,20 @@
               "anyOf": [
                 {
                   "type": ["boolean", "string"],
-                  "pattern": "^(true|false|yes|no)$"
+                  "pattern": "^(true|false)$"
                 },
                 {
                   "type": "object",
                   "properties": {
                     "allowed": {
                       "type": ["boolean", "string"],
-                      "pattern": "^(true|false|yes|no)$",
+                      "pattern": "^(true|false)$",
                       "description": "Whether or not this job can be retried manually",
                       "default": true
                     },
                     "permit_on_passed": {
                       "type": ["boolean", "string"],
-                      "pattern": "^(true|false|yes|no)$",
+                      "pattern": "^(true|false)$",
                       "description": "Whether or not this job can be retried after it has passed",
                       "default": true
                     },

--- a/schema.json
+++ b/schema.json
@@ -968,7 +968,8 @@
             "automatic": {
               "anyOf": [
                 {
-                  "type": "boolean"
+                  "type": ["boolean", "string"],
+                  "pattern": "^(true|false|yes|no)$"
                 },
                 {
                   "$ref": "#/definitions/commonOptions/automaticRetry"
@@ -992,18 +993,21 @@
               "description": "Whether to allow a job to be retried manually",
               "anyOf": [
                 {
-                  "type": "boolean"
+                  "type": ["boolean", "string"],
+                  "pattern": "^(true|false|yes|no)$"
                 },
                 {
                   "type": "object",
                   "properties": {
                     "allowed": {
-                      "type": "boolean",
+                      "type": ["boolean", "string"],
+                      "pattern": "^(true|false|yes|no)$",
                       "description": "Whether or not this job can be retried manually",
                       "default": true
                     },
                     "permit_on_passed": {
-                      "type": "boolean",
+                      "type": ["boolean", "string"],
+                      "pattern": "^(true|false|yes|no)$",
                       "description": "Whether or not this job can be retried after it has passed",
                       "default": true
                     },


### PR DESCRIPTION
The retry can be `"true"` or `true`, `"false"` or `false`, so we should allow those values in our schema, currently pipelines which use a `string` value will fail a schema validation.