### PR TITLE
SUP-2527 | Support `cache` in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -113,6 +113,22 @@
           [ "feature/*", "chore/*" ]
         ]
       },
+      "cache": {
+        "description": "The paths for the caches to be used in the step",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        ],
+        "examples": [
+          "dist/",
+          [ ".build/*", "assets/*" ]
+        ]
+      },
       "cancelOnBuildFailing": {
         "type": "boolean",
         "description": "Whether to cancel the job as soon as the build is marked as failing",

--- a/schema.json
+++ b/schema.json
@@ -122,11 +122,38 @@
           {
             "type": "array",
             "items": { "type": "string" }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "paths": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                ]
+              },
+              "size": {
+                "type": "string",
+                "pattern": "^\\d+g$"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["paths"]
           }
         ],
         "examples": [
           "dist/",
-          [ ".build/*", "assets/*" ]
+          [ ".build/*", "assets/*" ],
+          {
+            "name": "cool-cache",
+            "size": "20g",
+            "paths": ["/path/one", "/path/two"]
+          }
         ]
       },
       "cancelOnBuildFailing": {

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -187,9 +187,10 @@ steps:
         - matrix
 
   # With caching
-  # All the options
-
   - command: use cache
     cache:
       - "dist/"
       - "./src/target/"
+
+  - command: use cache
+    cache: "dist/"

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -185,3 +185,11 @@ steps:
         - env::FOO
         - plugins
         - matrix
+
+  # With caching
+  # All the options
+
+  - command: use cache
+    cache:
+      - "dist/"
+      - "./src/target/"


### PR DESCRIPTION
With Hosted Agents we support using `cache` as a step attribute, which implicitly creates a cache too. Currently that isn't defined so causes errors in pipeline files.

The `cache` attribute can accept a single string, or an array of strings. Tests included for both scenarios.