### PR TITLE
Update schema.json to set min retry value to

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -68,7 +68,7 @@
           "limit": {
             "type": "integer",
             "description": "The number of times this job can be retried",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 10
           },
           "signal": {


### PR DESCRIPTION
As per ticket and according to https://buildkite.com/blog/retrying-ci-cd-steps-when-spot-instances-terminate and tests, the minimum value in line 71 should be not 1 but 0.