### PR TITLE
place all definitions at the same level

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -19,533 +19,533 @@
     "steps"
   ],
   "definitions": {
-      "allowDependencyFailure": {
-        "type": "boolean",
-        "description": "Whether to proceed with this step and further steps if a step named in the depends_on attribute fails",
-        "default": false
-      },
-      "agents": {
-        "oneOf": [
-          { "$ref": "#/definitions/agentsObject" },
-          { "$ref": "#/definitions/agentsList" }
-        ]
-      },
-      "agentsObject": {
-        "type": "object",
-        "description": "Query rules to target specific agents",
-        "examples": [
-          { "queue": "deploy" },
-          { "ruby": "2*" }
-        ]
-      },
-      "agentsList": {
-        "type": "array",
-        "description": "Query rules to target specific agents in k=v format",
-        "examples": [
-          "queue=default",
-          "xcode=true"
-        ],
-        "items": {
-          "type": "string"
+    "allowDependencyFailure": {
+      "type": "boolean",
+      "description": "Whether to proceed with this step and further steps if a step named in the depends_on attribute fails",
+      "default": false
+    },
+    "agents": {
+      "oneOf": [
+        { "$ref": "#/definitions/agentsObject" },
+        { "$ref": "#/definitions/agentsList" }
+      ]
+    },
+    "agentsObject": {
+      "type": "object",
+      "description": "Query rules to target specific agents",
+      "examples": [
+        { "queue": "deploy" },
+        { "ruby": "2*" }
+      ]
+    },
+    "agentsList": {
+      "type": "array",
+      "description": "Query rules to target specific agents in k=v format",
+      "examples": [
+        "queue=default",
+        "xcode=true"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "automaticRetry": {
+      "type": "object",
+      "properties": {
+        "exit_status": {
+          "description": "The exit status number that will cause this job to retry",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [ "*" ]
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "description": "The number of times this job can be retried",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "signal": {
+          "description": "The exit signal, if any, that may be retried",
+          "type": "string",
+          "examples": [
+            "*",
+            "none",
+            "SIGKILL",
+            "term"
+          ]
+        },
+        "signal_reason": {
+          "description": "The exit signal reason, if any, that may be retried",
+          "type": "string",
+          "enum": [
+            "*",
+            "none",
+            "agent_refused",
+            "agent_stop",
+            "cancel",
+            "process_run_error",
+            "signature_rejected"
+          ]
         }
       },
-      "automaticRetry": {
-        "type": "object",
-        "properties": {
-          "exit_status": {
-            "description": "The exit status number that will cause this job to retry",
+      "additionalProperties": false
+    },
+    "branches": {
+      "description": "Which branches will include this step in their builds",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ],
+      "examples": [
+        "master",
+        [ "feature/*", "chore/*" ]
+      ]
+    },
+    "cache": {
+      "description": "The paths for the caches to be used in the step",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "paths": {
+              "anyOf": [
+                { "type": "string" },
+                {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              ]
+            },
+            "size": {
+              "type": "string",
+              "pattern": "^\\d+g$"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["paths"]
+        }
+      ],
+      "examples": [
+        "dist/",
+        [ ".build/*", "assets/*" ],
+        {
+          "name": "cool-cache",
+          "size": "20g",
+          "paths": ["/path/one", "/path/two"]
+        }
+      ]
+    },
+    "cancelOnBuildFailing": {
+      "type": "boolean",
+      "description": "Whether to cancel the job as soon as the build is marked as failing",
+      "default": false
+    },
+    "dependsOn": {
+      "description": "The step keys for a step to depend on",
+      "anyOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {
             "anyOf": [
+              {"type": "string"},
               {
-                "type": "string",
-                "enum": [ "*" ]
-              },
-              {
-                "type": "number"
+                "type": "object",
+                "properties": {
+                  "step": { "type": "string" },
+                  "allow_failure": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
               }
             ]
-          },
-          "limit": {
-            "type": "integer",
-            "description": "The number of times this job can be retried",
-            "minimum": 1,
-            "maximum": 10
-          },
-          "signal": {
-            "description": "The exit signal, if any, that may be retried",
-            "type": "string",
-            "examples": [
-              "*",
-              "none",
-              "SIGKILL",
-              "term"
-            ]
-          },
-          "signal_reason": {
-            "description": "The exit signal reason, if any, that may be retried",
-            "type": "string",
-            "enum": [
-              "*",
-              "none",
-              "agent_refused",
-              "agent_stop",
-              "cancel",
-              "process_run_error",
-              "signature_rejected"
-            ]
           }
-        },
-        "additionalProperties": false
-      },
-      "branches": {
-        "description": "Which branches will include this step in their builds",
-        "anyOf": [
+        }
+      ]
+    },
+    "env": {
+      "type": "object",
+      "description": "Environment variables for this step",
+      "examples": [
+        { "NODE_ENV": "test" }
+      ]
+    },
+    "identifier": {
+      "type": "string",
+      "description": "A string identifier",
+      "examples": [ "an-id" ]
+    },
+    "if": {
+      "type": "string",
+      "description": "A boolean expression that omits the step when false",
+      "examples": [ "build.message != 'skip me'", "build.branch == 'master'" ]
+    },
+    "key": {
+      "type": "string",
+      "description": "A unique identifier for a step, must not resemble a UUID",
+      "examples": [ "deploy-staging", "test-integration" ]
+    },
+    "label": {
+      "type": "string",
+      "description": "The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.",
+      "examples": [ ":docker: Build" ]
+    },
+    "buildNotify": {
+      "type": "array",
+      "description": "Array of notification options for this step",
+      "items": {
+        "oneOf": [
           {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": { "type": "string" }
-          }
-        ],
-        "examples": [
-          "master",
-          [ "feature/*", "chore/*" ]
-        ]
-      },
-      "cache": {
-        "description": "The paths for the caches to be used in the step",
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": { "type": "string" }
+            "type": "string",
+            "enum": ["github_check", "github_commit_status"]
           },
           {
             "type": "object",
             "properties": {
-              "paths": {
-                "anyOf": [
-                  { "type": "string" },
+              "email": {
+                "type": "string"
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "basecamp_campfire": {
+                "type": "string"
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "slack": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "channels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "webhook": {
+                "type": "string"
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "pagerduty_change_event": {
+                "type": "string"
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "github_commit_status": {
+                "type": "object",
+                "properties": {
+                  "context": {
+                    "description": "GitHub commit status name",
+                    "type": "string"
+                  }
+                }
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "github_check": {
+                "type": "object",
+                "properties": {
+                  "context": {
+                    "description": "GitHub commit status name",
+                    "type": "string"
+                  }
+                }
+              },
+              "if": {
+                "$ref": "#/definitions/if"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "fields": {
+      "type": "array",
+      "description": "A list of input fields required to be filled out before unblocking the step",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "The text input name",
+                "examples": [
+                  "Release Name"
+                ]
+              },
+              "key": {
+                "type": "string",
+                "description": "The meta-data key that stores the field's input",
+                "pattern": "^[a-zA-Z0-9-_]+$",
+                "examples": [
+                  "release-name"
+                ]
+              },
+              "hint": {
+                "type": "string",
+                "description": "The explanatory text that is shown after the label",
+                "examples": [
+                  "What’s the code name for this release? :name_badge:"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "description": "The format must be a regular expression implicitly anchored to the beginning and end of the input and is functionally equivalent to the HTML5 pattern attribute.",
+                "format": "regex",
+                "examples": [
+                  "[0-9a-f]+"
+                ]
+              },
+              "required": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether the field is required for form submission"
+              },
+              "default": {
+                "type": "string",
+                "description": "The value that is pre-filled in the text field",
+                "examples": [
+                  "Flying Dolphin"
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "key"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "select": {
+                "type": "string",
+                "description": "The text input name",
+                "examples": [
+                  "Release Stream"
+                ]
+              },
+              "key": {
+                "type": "string",
+                "description": "The meta-data key that stores the field's input",
+                "pattern": "^[a-zA-Z0-9-_]+$",
+                "examples": [
+                  "release-stream"
+                ]
+              },
+              "default": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
                   {
                     "type": "array",
                     "items": { "type": "string" }
                   }
+                ],
+                "description": "The value of the option(s) that will be pre-selected in the dropdown",
+                "examples": [ "beta" , [ "alpha" , "beta" ] ]
+              },
+              "hint": {
+                "type": "string",
+                "description": "The explanatory text that is shown after the label",
+                "examples": [
+                  "What’s the code name for this release? :name_badge:"
                 ]
               },
-              "size": {
-                "type": "string",
-                "pattern": "^\\d+g$"
+              "multiple": {
+                "type": "boolean",
+                "description": "Whether more than one option may be selected",
+                "default": false
+                },
+              "options": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string",
+                      "description": "The text displayed on the select list item",
+                      "examples": [ "Stable" ]
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The value to be stored as meta-data",
+                      "examples": [ "stable" ]
+                    },
+                    "hint": {
+                      "type": "string",
+                      "description": "The text displayed directly under the select field’s label",
+                      "examples": [
+                        "Which release stream does this belong in? :fork:"
+                      ]
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Whether the field is required for form submission"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "label",
+                    "value"
+                  ]
+                }
               },
-              "name": {
-                "type": "string"
+              "required": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether the field is required for form submission"
               }
             },
-            "required": ["paths"]
-          }
-        ],
-        "examples": [
-          "dist/",
-          [ ".build/*", "assets/*" ],
-          {
-            "name": "cool-cache",
-            "size": "20g",
-            "paths": ["/path/one", "/path/two"]
+            "additionalProperties": false,
+            "required": [
+              "key",
+              "options"
+            ]
           }
         ]
-      },
-      "cancelOnBuildFailing": {
-        "type": "boolean",
-        "description": "Whether to cancel the job as soon as the build is marked as failing",
-        "default": false
-      },
-      "dependsOn": {
-        "description": "The step keys for a step to depend on",
-        "anyOf": [
-          {"type": "null"},
-          {"type": "string"},
-          {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {"type": "string"},
-                {
-                  "type": "object",
-                  "properties": {
-                    "step": { "type": "string" },
-                    "allow_failure": {
-                      "type": "boolean",
-                      "default": false
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            }
-          }
-        ]
-      },
-      "env": {
-        "type": "object",
-        "description": "Environment variables for this step",
-        "examples": [
-          { "NODE_ENV": "test" }
-        ]
-      },
-      "identifier": {
-        "type": "string",
-        "description": "A string identifier",
-        "examples": [ "an-id" ]
-      },
-      "if": {
-        "type": "string",
-        "description": "A boolean expression that omits the step when false",
-        "examples": [ "build.message != 'skip me'", "build.branch == 'master'" ]
-      },
-      "key": {
-        "type": "string",
-        "description": "A unique identifier for a step, must not resemble a UUID",
-        "examples": [ "deploy-staging", "test-integration" ]
-      },
-      "label": {
-        "type": "string",
-        "description": "The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.",
-        "examples": [ ":docker: Build" ]
-      },
-      "buildNotify": {
-        "type": "array",
-        "description": "Array of notification options for this step",
-        "items": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["github_check", "github_commit_status"]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "type": "string"
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "basecamp_campfire": {
-                  "type": "string"
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "slack": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "channels": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "message": {
-                          "type": "string"
-                        }
+      }
+    },
+    "matrixElement": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "boolean"}
+      ]
+    },
+    "prompt": {
+      "type": "string",
+      "description": "The instructional message displayed in the dialog box when the unblock step is activated",
+      "examples": [
+        "Release to production?"
+      ]
+    },
+    "skip": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "type": "string" }
+      ],
+      "description": "Whether this step should be skipped. You can specify a reason for using a string.",
+      "examples": [
+        true,
+        false,
+        "My reason"
+      ]
+    },
+    "softFail": {
+      "description": "The conditions for marking the step as a soft-fail.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "exit_status": {
+                    "description": "The exit status number that will cause this job to soft-fail",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [ "*" ]
+                      },
+                      {
+                        "type": "number"
                       }
-                    }
-                  ]
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "webhook": {
-                  "type": "string"
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "pagerduty_change_event": {
-                  "type": "string"
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "github_commit_status": {
-                  "type": "object",
-                  "properties": {
-                    "context": {
-                      "description": "GitHub commit status name",
-                      "type": "string"
-                    }
-                  }
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "github_check": {
-                  "type": "object",
-                  "properties": {
-                    "context": {
-                      "description": "GitHub commit status name",
-                      "type": "string"
-                    }
-                  }
-                },
-                "if": {
-                  "$ref": "#/definitions/if"
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "fields": {
-        "type": "array",
-        "description": "A list of input fields required to be filled out before unblocking the step",
-        "items": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "The text input name",
-                  "examples": [
-                    "Release Name"
-                  ]
-                },
-                "key": {
-                  "type": "string",
-                  "description": "The meta-data key that stores the field's input",
-                  "pattern": "^[a-zA-Z0-9-_]+$",
-                  "examples": [
-                    "release-name"
-                  ]
-                },
-                "hint": {
-                  "type": "string",
-                  "description": "The explanatory text that is shown after the label",
-                  "examples": [
-                    "What’s the code name for this release? :name_badge:"
-                  ]
-                },
-                "format": {
-                  "type": "string",
-                  "description": "The format must be a regular expression implicitly anchored to the beginning and end of the input and is functionally equivalent to the HTML5 pattern attribute.",
-                  "format": "regex",
-                  "examples": [
-                    "[0-9a-f]+"
-                  ]
-                },
-                "required": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "Whether the field is required for form submission"
-                },
-                "default": {
-                  "type": "string",
-                  "description": "The value that is pre-filled in the text field",
-                  "examples": [
-                    "Flying Dolphin"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "key"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "select": {
-                  "type": "string",
-                  "description": "The text input name",
-                  "examples": [
-                    "Release Stream"
-                  ]
-                },
-                "key": {
-                  "type": "string",
-                  "description": "The meta-data key that stores the field's input",
-                  "pattern": "^[a-zA-Z0-9-_]+$",
-                  "examples": [
-                    "release-stream"
-                  ]
-                },
-                "default": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "array",
-                      "items": { "type": "string" }
-                    }
-                  ],
-                  "description": "The value of the option(s) that will be pre-selected in the dropdown",
-                  "examples": [ "beta" , [ "alpha" , "beta" ] ]
-                },
-                "hint": {
-                  "type": "string",
-                  "description": "The explanatory text that is shown after the label",
-                  "examples": [
-                    "What’s the code name for this release? :name_badge:"
-                  ]
-                },
-                "multiple": {
-                  "type": "boolean",
-                  "description": "Whether more than one option may be selected",
-                  "default": false
-                  },
-                "options": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": "string",
-                        "description": "The text displayed on the select list item",
-                        "examples": [ "Stable" ]
-                      },
-                      "value": {
-                        "type": "string",
-                        "description": "The value to be stored as meta-data",
-                        "examples": [ "stable" ]
-                      },
-                      "hint": {
-                        "type": "string",
-                        "description": "The text displayed directly under the select field’s label",
-                        "examples": [
-                          "Which release stream does this belong in? :fork:"
-                        ]
-                      },
-                      "required": {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Whether the field is required for form submission"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                      "label",
-                      "value"
                     ]
                   }
-                },
-                "required": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "Whether the field is required for form submission"
                 }
-              },
-              "additionalProperties": false,
-              "required": [
-                "key",
-                "options"
-              ]
-            }
-          ]
-        }
-      },
-      "matrixElement": {
-        "oneOf": [
-          {"type": "string"},
-          {"type": "integer"},
-          {"type": "boolean"}
-        ]
-      },
-      "prompt": {
-        "type": "string",
-        "description": "The instructional message displayed in the dialog box when the unblock step is activated",
-        "examples": [
-          "Release to production?"
-        ]
-      },
-      "skip": {
-        "anyOf": [
-          { "type": "boolean" },
-          { "type": "string" }
-        ],
-        "description": "Whether this step should be skipped. You can specify a reason for using a string.",
-        "examples": [
-          true,
-          false,
-          "My reason"
-        ]
-      },
-      "softFail": {
-        "description": "The conditions for marking the step as a soft-fail.",
-        "anyOf": [
-          {
-            "type": "boolean"
-          },
-          {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "exit_status": {
-                      "description": "The exit status number that will cause this job to soft-fail",
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": [ "*" ]
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+              }
+            ]
           }
-        ]
-      },
+        }
+      ]
+    },
     "blockStep": {
       "type": "object",
       "properties": {

--- a/schema.json
+++ b/schema.json
@@ -19,7 +19,6 @@
     "steps"
   ],
   "definitions": {
-    "commonOptions": {
       "allowDependencyFailure": {
         "type": "boolean",
         "description": "Whether to proceed with this step and further steps if a step named in the depends_on attribute fails",
@@ -27,8 +26,8 @@
       },
       "agents": {
         "oneOf": [
-          { "$ref": "#/definitions/commonOptions/agentsObject" },
-          { "$ref": "#/definitions/commonOptions/agentsList" }
+          { "$ref": "#/definitions/agentsObject" },
+          { "$ref": "#/definitions/agentsList" }
         ]
       },
       "agentsObject": {
@@ -230,7 +229,7 @@
                   "type": "string"
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -242,7 +241,7 @@
                   "type": "string"
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -272,7 +271,7 @@
                   ]
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -284,7 +283,7 @@
                   "type": "string"
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -296,7 +295,7 @@
                   "type": "string"
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -314,7 +313,7 @@
                   }
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -332,7 +331,7 @@
                   }
                 },
                 "if": {
-                  "$ref": "#/definitions/commonOptions/if"
+                  "$ref": "#/definitions/if"
                 }
               },
               "additionalProperties": false
@@ -546,13 +545,12 @@
             }
           }
         ]
-      }
-    },
+      },
     "blockStep": {
       "type": "object",
       "properties": {
         "allow_dependency_failure": {
-          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+          "$ref": "#/definitions/allowDependencyFailure"
         },
         "block": {
           "type": "string",
@@ -564,34 +562,34 @@
           "enum": [ "passed", "failed", "running" ]
         },
         "branches": {
-          "$ref": "#/definitions/commonOptions/branches"
+          "$ref": "#/definitions/branches"
         },
         "depends_on": {
-          "$ref": "#/definitions/commonOptions/dependsOn"
+          "$ref": "#/definitions/dependsOn"
         },
         "fields": {
-          "$ref": "#/definitions/commonOptions/fields"
+          "$ref": "#/definitions/fields"
         },
         "id": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "identifier": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "if": {
-          "$ref": "#/definitions/commonOptions/if"
+          "$ref": "#/definitions/if"
         },
         "key": {
-          "$ref": "#/definitions/commonOptions/key"
+          "$ref": "#/definitions/key"
         },
         "label": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "name": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "prompt": {
-          "$ref": "#/definitions/commonOptions/prompt"
+          "$ref": "#/definitions/prompt"
         },
         "type": {
           "type": "string",
@@ -618,41 +616,41 @@
       "type": "object",
       "properties": {
         "allow_dependency_failure": {
-          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+          "$ref": "#/definitions/allowDependencyFailure"
         },
         "input": {
           "type": "string",
           "description": "The label of the input step"
         },
         "branches": {
-          "$ref": "#/definitions/commonOptions/branches"
+          "$ref": "#/definitions/branches"
         },
         "depends_on": {
-          "$ref": "#/definitions/commonOptions/dependsOn"
+          "$ref": "#/definitions/dependsOn"
         },
         "fields": {
-          "$ref": "#/definitions/commonOptions/fields"
+          "$ref": "#/definitions/fields"
         },
         "id": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "identifier": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "if": {
-          "$ref": "#/definitions/commonOptions/if"
+          "$ref": "#/definitions/if"
         },
         "key": {
-          "$ref": "#/definitions/commonOptions/key"
+          "$ref": "#/definitions/key"
         },
         "label": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "name": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "prompt": {
-          "$ref": "#/definitions/commonOptions/prompt"
+          "$ref": "#/definitions/prompt"
         },
         "type": {
           "type": "string",
@@ -679,10 +677,10 @@
       "type": "object",
       "properties": {
         "agents": {
-          "$ref": "#/definitions/commonOptions/agents"
+          "$ref": "#/definitions/agents"
         },
         "allow_dependency_failure": {
-          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+          "$ref": "#/definitions/allowDependencyFailure"
         },
         "artifact_paths": {
           "anyOf": [
@@ -701,10 +699,13 @@
           ]
         },
         "branches": {
-          "$ref": "#/definitions/commonOptions/branches"
+          "$ref": "#/definitions/branches"
+        },
+        "cache": {
+          "$ref": "#/definitions/cache"
         },
         "cancel_on_build_failing": {
-          "$ref": "#/definitions/commonOptions/cancelOnBuildFailing"
+          "$ref": "#/definitions/cancelOnBuildFailing"
         },
         "command": {
           "description": "The commands to run on the agent",
@@ -740,25 +741,25 @@
           ]
         },
         "depends_on": {
-          "$ref": "#/definitions/commonOptions/dependsOn"
+          "$ref": "#/definitions/dependsOn"
         },
         "env": {
-          "$ref": "#/definitions/commonOptions/env"
+          "$ref": "#/definitions/env"
         },
         "id": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "identifier": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "if": {
-          "$ref": "#/definitions/commonOptions/if"
+          "$ref": "#/definitions/if"
         },
         "key": {
-          "$ref": "#/definitions/commonOptions/key"
+          "$ref": "#/definitions/key"
         },
         "label": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "signature": {
           "type": "object",
@@ -788,7 +789,7 @@
             {
               "type": "array",
               "description": "List of elements for simple single-dimension Build Matrix",
-              "items": { "$ref": "#/definitions/commonOptions/matrixElement" },
+              "items": { "$ref": "#/definitions/matrixElement" },
               "examples": [
                 ["linux", "freebsd"]
               ]
@@ -802,7 +803,7 @@
                     {
                       "type": "array",
                       "description": "List of elements for single-dimension Build Matrix",
-                      "items": { "$ref": "#/definitions/commonOptions/matrixElement" },
+                      "items": { "$ref": "#/definitions/matrixElement" },
                       "examples": [
                         ["linux", "freebsd"]
                       ]
@@ -818,7 +819,7 @@
                       "additionalProperties": {
                         "type": "array",
                         "description": "List of elements for this Build Matrix dimension",
-                        "items": { "$ref": "#/definitions/commonOptions/matrixElement" }
+                        "items": { "$ref": "#/definitions/matrixElement" }
                       },
                       "examples": [
                         {
@@ -841,7 +842,7 @@
                           {
                             "type": "array",
                             "description": "List of existing or new elements for single-dimension Build Matrix",
-                            "items": { "$ref": "#/definitions/commonOptions/matrixElement" }
+                            "items": { "$ref": "#/definitions/matrixElement" }
                           },
                           {
                             "type": "object",
@@ -861,10 +862,10 @@
                         ]
                       },
                       "skip": {
-                        "$ref": "#/definitions/commonOptions/skip"
+                        "$ref": "#/definitions/skip"
                       },
                       "soft_fail": {
-                        "$ref": "#/definitions/commonOptions/softFail"
+                        "$ref": "#/definitions/softFail"
                       }
                     },
                     "required": ["with"]
@@ -876,7 +877,7 @@
           ]
         },
         "name": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "notify": {
           "type": "array",
@@ -894,7 +895,7 @@
                     "type": "string"
                   },
                   "if": {
-                    "$ref": "#/definitions/commonOptions/if"
+                    "$ref": "#/definitions/if"
                   }
                 },
                 "additionalProperties": false
@@ -924,7 +925,7 @@
                     ]
                   },
                   "if": {
-                    "$ref": "#/definitions/commonOptions/if"
+                    "$ref": "#/definitions/if"
                   }
                 },
                 "additionalProperties": false
@@ -942,7 +943,7 @@
                     }
                   },
                   "if": {
-                    "$ref": "#/definitions/commonOptions/if"
+                    "$ref": "#/definitions/if"
                   }
                 },
                 "additionalProperties": false
@@ -960,7 +961,7 @@
                     }
                   },
                   "if": {
-                    "$ref": "#/definitions/commonOptions/if"
+                    "$ref": "#/definitions/if"
                   }
                 },
                 "additionalProperties": false
@@ -1002,7 +1003,7 @@
           ]
         },
         "soft_fail": {
-          "$ref": "#/definitions/commonOptions/softFail"
+          "$ref": "#/definitions/softFail"
         },
         "retry": {
           "type": "object",
@@ -1015,12 +1016,12 @@
                   "pattern": "^(true|false)$"
                 },
                 {
-                  "$ref": "#/definitions/commonOptions/automaticRetry"
+                  "$ref": "#/definitions/automaticRetry"
                 },
                 {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/commonOptions/automaticRetry"
+                    "$ref": "#/definitions/automaticRetry"
                   }
                 }
               ],
@@ -1069,7 +1070,7 @@
           }
         },
         "skip": {
-          "$ref": "#/definitions/commonOptions/skip"
+          "$ref": "#/definitions/skip"
         },
         "timeout_in_minutes": {
           "type": "integer",
@@ -1112,26 +1113,26 @@
       "type": "object",
       "properties": {
         "allow_dependency_failure": {
-          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+          "$ref": "#/definitions/allowDependencyFailure"
         },
         "continue_on_failure": {
           "description": "Continue to the next steps, even if the previous group of steps fail",
           "type": "boolean"
         },
         "depends_on": {
-          "$ref": "#/definitions/commonOptions/dependsOn"
+          "$ref": "#/definitions/dependsOn"
         },
         "id": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "identifier": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "if": {
-          "$ref": "#/definitions/commonOptions/if"
+          "$ref": "#/definitions/if"
         },
         "key": {
-          "$ref": "#/definitions/commonOptions/key"
+          "$ref": "#/definitions/key"
         },
         "type": {
           "type": "string",
@@ -1170,7 +1171,7 @@
       "type": "object",
       "properties": {
         "allow_dependency_failure": {
-          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+          "$ref": "#/definitions/allowDependencyFailure"
         },
         "async": {
           "type": "boolean",
@@ -1178,7 +1179,7 @@
           "description": "Whether to continue the build without waiting for the triggered step to complete"
         },
         "branches": {
-          "$ref": "#/definitions/commonOptions/branches"
+          "$ref": "#/definitions/branches"
         },
         "build": {
           "type": "object",
@@ -1203,13 +1204,13 @@
               ]
             },
             "env": {
-              "$ref": "#/definitions/commonOptions/env"
+              "$ref": "#/definitions/env"
             },
             "label": {
-              "$ref": "#/definitions/commonOptions/label"
+              "$ref": "#/definitions/label"
             },
             "name": {
-              "$ref": "#/definitions/commonOptions/label"
+              "$ref": "#/definitions/label"
             },
             "message": {
               "type": "string",
@@ -1241,25 +1242,25 @@
           "additionalProperties": false
         },
         "depends_on": {
-          "$ref": "#/definitions/commonOptions/dependsOn"
+          "$ref": "#/definitions/dependsOn"
         },
         "id": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "identifier": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "if": {
-          "$ref": "#/definitions/commonOptions/if"
+          "$ref": "#/definitions/if"
         },
         "key": {
-          "$ref": "#/definitions/commonOptions/key"
+          "$ref": "#/definitions/key"
         },
         "label": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "name": {
-          "$ref": "#/definitions/commonOptions/label"
+          "$ref": "#/definitions/label"
         },
         "type": {
           "type": "string",
@@ -1270,10 +1271,10 @@
           "description": "The slug of the pipeline to create a build"
         },
         "skip": {
-          "$ref": "#/definitions/commonOptions/skip"
+          "$ref": "#/definitions/skip"
         },
         "soft_fail": {
-          "$ref": "#/definitions/commonOptions/softFail"
+          "$ref": "#/definitions/softFail"
         }
       },
       "additionalProperties": false
@@ -1290,7 +1291,7 @@
     "groupStep": {
       "properties": {
         "depends_on": {
-          "$ref": "#/definitions/commonOptions/dependsOn"
+          "$ref": "#/definitions/dependsOn"
         },
         "group": {
           "type": [ "string", "null" ],
@@ -1298,16 +1299,16 @@
           "examples": [ "Tests" ]
         },
         "id": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "identifier": {
-          "$ref": "#/definitions/commonOptions/identifier"
+          "$ref": "#/definitions/identifier"
         },
         "if": {
-          "$ref": "#/definitions/commonOptions/if"
+          "$ref": "#/definitions/if"
         },
         "key": {
-          "$ref": "#/definitions/commonOptions/key"
+          "$ref": "#/definitions/key"
         },
         "label": {
           "$ref": "#/definitions/groupStep/properties/group"
@@ -1316,13 +1317,13 @@
           "$ref": "#/definitions/groupStep/properties/label"
         },
         "allow_dependency_failure": {
-          "$ref": "#/definitions/commonOptions/allowDependencyFailure"
+          "$ref": "#/definitions/allowDependencyFailure"
         },
         "notify": {
-          "$ref": "#/definitions/commonOptions/buildNotify"
+          "$ref": "#/definitions/buildNotify"
         },
         "skip": {
-          "$ref": "#/definitions/commonOptions/skip"
+          "$ref": "#/definitions/skip"
         },
         "steps": {
           "type": "array",
@@ -1355,13 +1356,13 @@
   },
   "properties": {
     "env": {
-      "$ref": "#/definitions/commonOptions/env"
+      "$ref": "#/definitions/env"
     },
     "agents": {
-      "$ref": "#/definitions/commonOptions/agents"
+      "$ref": "#/definitions/agents"
     },
     "notify": {
-      "$ref": "#/definitions/commonOptions/buildNotify"
+      "$ref": "#/definitions/buildNotify"
     },
     "steps": {
       "description": "A list of steps",


### PR DESCRIPTION
The JSON Schema draft-06 [says](https://json-schema.org/draft-06/draft-wright-json-schema-validation-01#rfc.section.7.1) of the `definitions` keyword:

> This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.

In the buildkite schema, the `definitions/commonOptions` property is used
to namespace schemas, not as a schema itself, which doesn't seem
to fit the intended structure for `definitions`, even though technically it's just about
OK because none of the properties happen to coincide with keywords
defined in draft-06 (`"if"` was only defined in draft-07) and unknown keywords
are ignored.

Referring to definitions that aren't in regular schema locations is also
in a grey area. Later versions of the spec have [this to say](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#section-9.4.2):

> a reference target under a known keyword, for which the value is known not to be a schema, results in undefined behavior

Even though draft-06 doesn't include this wording, it seems that the reasoning
still applies.

So to avoid the above issues, this PR moves all the definitions that
were inside `commonOptions` into the top level `definitions` property.

The distinction between the two kinds of definitions is still clear by virtue
of the `Step` suffix used for all the actual step definitions and not for
the others.

Some other possibilities:

1. give all the schemas inside `commonOptions` a common prefix, such as "common.", so we'd have `#/definitions/common.env` etc.
2. move all the definitions inside `commonOptions` one level down into another `definitions` property, so we'd have `#/definitions/commonOptions/definitions/env` etc.

Both of those seem unneccessarily verbose to me, but YMMV.

I have verified that the tests pass with this change in place,
assuming #83 is landed as a prereq.

I've split this PR into two commits to make the diffs easier to see.
The first one leaves the indentation inplace; the second aligns it correctly.
