### PR TITLE
add types for top level schema and groupStep

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -15,6 +15,7 @@
     ".buildkite/pipeline.*.yaml",
     ".buildkite/pipeline.*.json"
   ],
+  "type": "object",
   "required": [
     "steps"
   ],
@@ -1288,6 +1289,7 @@
       "additionalProperties": false
     },
     "groupStep": {
+      "type": "object",
       "properties": {
         "depends_on": {
           "$ref": "#/definitions/commonOptions/dependsOn"


### PR DESCRIPTION
The top level schema currently allows non-object types, such as numbers and strings, but that's probably not intended, so require it to be object type.

Similar reasoning applies to `groupStep`.