### PR TITLE
remove commonOptions from cache definition

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -705,7 +705,7 @@
           "$ref": "#/definitions/cache"
         },
         "cache": {
-          "$ref": "#/definitions/commonOptions/cache"
+          "$ref": "#/definitions/cache"
         },
         "cancel_on_build_failing": {
           "$ref": "#/definitions/cancelOnBuildFailing"


### PR DESCRIPTION
fix for failing specs caused by https://github.com/buildkite/pipeline-schema/pull/84/https://github.com/buildkite/pipeline-schema/pull/83  which still referenced commonOptions