### PR TITLE
Add support for an array of exit_status codes

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,10 @@
             },
             {
               "type": "number"
+            },
+            {
+              "type": "array",
+              "items": { "type": "number" }
             }
           ]
         },

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -105,6 +105,11 @@ steps:
       automatic: true
 
   - command: test
+    retry:
+      automatic:
+        exit_status: [1,2,3]
+
+  - command: test
     skip: true
 
   - command: test


### PR DESCRIPTION
Adds support for an array of exit status codes. These must be numbers.

The following is considered valid:

```yml
  - command: test
    retry:
      automatic:
        exit_status: [1,2,3]
```

The following is not valid:

```yml
  - command: test
    retry:
      automatic:
        exit_status: ["not", "valid"]
```