### PR TITLE
Improve the key/identifier/id situation

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -582,7 +582,7 @@
         },
         "id": {
           "$ref": "#/definitions/blockStep/properties/key",
-          "deprecated": true,
+          "deprecated": true
         },
         "label": {
           "$ref": "#/definitions/label"

--- a/schema.json
+++ b/schema.json
@@ -644,7 +644,7 @@
         },
         "id": {
           "$ref": "#/definitions/inputStep/properties/key",
-          "deprecated": true,
+          "deprecated": true
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -763,7 +763,7 @@
         },
         "id": {
           "$ref": "#/definitions/commandStep/properties/key",
-          "deprecated": true,
+          "deprecated": true
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -1140,7 +1140,7 @@
         },
         "id": {
           "$ref": "#/definitions/waitStep/properties/key",
-          "deprecated": true,
+          "deprecated": true
         },
         "type": {
           "type": "string",
@@ -1246,7 +1246,7 @@
         },
         "id": {
           "$ref": "#/definitions/triggerStep/properties/key",
-          "deprecated": true,
+          "deprecated": true
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -1302,7 +1302,7 @@
         },
         "id": {
           "$ref": "#/definitions/groupStep/properties/key",
-          "deprecated": true,
+          "deprecated": true
         },
         "label": {
           "$ref": "#/definitions/groupStep/properties/group"

--- a/schema.json
+++ b/schema.json
@@ -197,12 +197,7 @@
       "examples": [
         { "NODE_ENV": "test" }
       ]
-    },
-    "identifier": {
-      "type": "string",
-      "description": "A string identifier",
-      "examples": [ "an-id" ]
-    },
+    },f
     "if": {
       "type": "string",
       "description": "A boolean expression that omits the step when false",
@@ -211,7 +206,8 @@
     "key": {
       "type": "string",
       "description": "A unique identifier for a step, must not resemble a UUID",
-      "examples": [ "deploy-staging", "test-integration" ]
+      "examples": [ "deploy-staging", "test-integration" ],
+      "pattern": "^(?!^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$).*$"
     },
     "label": {
       "type": "string",
@@ -575,17 +571,18 @@
         "fields": {
           "$ref": "#/definitions/fields"
         },
-        "id": {
-          "$ref": "#/definitions/identifier"
-        },
-        "identifier": {
-          "$ref": "#/definitions/identifier"
-        },
         "if": {
           "$ref": "#/definitions/if"
         },
         "key": {
           "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/key"
+        },
+        "id": {
+          "$ref": "#/definitions/key",
+          "deprecated": true,
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -636,17 +633,18 @@
         "fields": {
           "$ref": "#/definitions/fields"
         },
-        "id": {
-          "$ref": "#/definitions/identifier"
-        },
-        "identifier": {
-          "$ref": "#/definitions/identifier"
-        },
         "if": {
           "$ref": "#/definitions/if"
         },
         "key": {
           "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/key"
+        },
+        "id": {
+          "$ref": "#/definitions/key",
+          "deprecated": true,
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -754,17 +752,18 @@
         "env": {
           "$ref": "#/definitions/env"
         },
-        "id": {
-          "$ref": "#/definitions/identifier"
-        },
-        "identifier": {
-          "$ref": "#/definitions/identifier"
-        },
         "if": {
           "$ref": "#/definitions/if"
         },
         "key": {
           "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/key"
+        },
+        "id": {
+          "$ref": "#/definitions/key",
+          "deprecated": true,
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -1130,17 +1129,18 @@
         "depends_on": {
           "$ref": "#/definitions/dependsOn"
         },
-        "id": {
-          "$ref": "#/definitions/identifier"
-        },
-        "identifier": {
-          "$ref": "#/definitions/identifier"
-        },
         "if": {
           "$ref": "#/definitions/if"
         },
         "key": {
           "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/key"
+        },
+        "id": {
+          "$ref": "#/definitions/key",
+          "deprecated": true,
         },
         "type": {
           "type": "string",
@@ -1235,17 +1235,18 @@
         "depends_on": {
           "$ref": "#/definitions/dependsOn"
         },
-        "id": {
-          "$ref": "#/definitions/identifier"
-        },
-        "identifier": {
-          "$ref": "#/definitions/identifier"
-        },
         "if": {
           "$ref": "#/definitions/if"
         },
         "key": {
           "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/key"
+        },
+        "id": {
+          "$ref": "#/definitions/key",
+          "deprecated": true,
         },
         "label": {
           "$ref": "#/definitions/label"
@@ -1290,17 +1291,18 @@
           "description": "The name to give to this group of steps",
           "examples": [ "Tests" ]
         },
-        "id": {
-          "$ref": "#/definitions/identifier"
-        },
-        "identifier": {
-          "$ref": "#/definitions/identifier"
-        },
         "if": {
           "$ref": "#/definitions/if"
         },
         "key": {
           "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/key"
+        },
+        "id": {
+          "$ref": "#/definitions/key",
+          "deprecated": true,
         },
         "label": {
           "$ref": "#/definitions/groupStep/properties/group"

--- a/schema.json
+++ b/schema.json
@@ -197,7 +197,7 @@
       "examples": [
         { "NODE_ENV": "test" }
       ]
-    },f
+    },
     "if": {
       "type": "string",
       "description": "A boolean expression that omits the step when false",

--- a/schema.json
+++ b/schema.json
@@ -207,7 +207,7 @@
       "type": "string",
       "description": "A unique identifier for a step, must not resemble a UUID",
       "examples": [ "deploy-staging", "test-integration" ],
-      "pattern": "^(?!^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$).*$"
+      "pattern": "^(?!^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$).*$"
     },
     "label": {
       "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -578,10 +578,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/blockStep/key"
+          "$ref": "#/definitions/blockStep/properties/key"
         },
         "id": {
-          "$ref": "#/definitions/blockStep/key",
+          "$ref": "#/definitions/blockStep/properties/key",
           "deprecated": true,
         },
         "label": {
@@ -640,10 +640,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/inputStep/key"
+          "$ref": "#/definitions/inputStep/properties/key"
         },
         "id": {
-          "$ref": "#/definitions/inputStep/key",
+          "$ref": "#/definitions/inputStep/properties/key",
           "deprecated": true,
         },
         "label": {
@@ -759,10 +759,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/commandStep/key"
+          "$ref": "#/definitions/commandStep/properties/key"
         },
         "id": {
-          "$ref": "#/definitions/commandStep/key",
+          "$ref": "#/definitions/commandStep/properties/key",
           "deprecated": true,
         },
         "label": {
@@ -1136,10 +1136,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/waitStep/key"
+          "$ref": "#/definitions/waitStep/properties/key"
         },
         "id": {
-          "$ref": "#/definitions/waitStep/key",
+          "$ref": "#/definitions/waitStep/properties/key",
           "deprecated": true,
         },
         "type": {
@@ -1242,10 +1242,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/triggerStep/key"
+          "$ref": "#/definitions/triggerStep/proprties/key"
         },
         "id": {
-          "$ref": "#/definitions/triggerStep/key",
+          "$ref": "#/definitions/triggerStep/properties/key",
           "deprecated": true,
         },
         "label": {
@@ -1298,10 +1298,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/groupStep/key"
+          "$ref": "#/definitions/groupStep/properties/key"
         },
         "id": {
-          "$ref": "#/definitions/groupStep/key",
+          "$ref": "#/definitions/groupStep/properties/key",
           "deprecated": true,
         },
         "label": {

--- a/schema.json
+++ b/schema.json
@@ -578,10 +578,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/key"
+          "$ref": "#/definitions/blockStep/key"
         },
         "id": {
-          "$ref": "#/definitions/key",
+          "$ref": "#/definitions/blockStep/key",
           "deprecated": true,
         },
         "label": {
@@ -640,10 +640,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/key"
+          "$ref": "#/definitions/inputStep/key"
         },
         "id": {
-          "$ref": "#/definitions/key",
+          "$ref": "#/definitions/inputStep/key",
           "deprecated": true,
         },
         "label": {
@@ -759,10 +759,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/key"
+          "$ref": "#/definitions/commandStep/key"
         },
         "id": {
-          "$ref": "#/definitions/key",
+          "$ref": "#/definitions/commandStep/key",
           "deprecated": true,
         },
         "label": {
@@ -1136,10 +1136,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/key"
+          "$ref": "#/definitions/waitStep/key"
         },
         "id": {
-          "$ref": "#/definitions/key",
+          "$ref": "#/definitions/waitStep/key",
           "deprecated": true,
         },
         "type": {
@@ -1242,10 +1242,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/key"
+          "$ref": "#/definitions/triggerStep/key"
         },
         "id": {
-          "$ref": "#/definitions/key",
+          "$ref": "#/definitions/triggerStep/key",
           "deprecated": true,
         },
         "label": {
@@ -1298,10 +1298,10 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/key"
+          "$ref": "#/definitions/groupStep/key"
         },
         "id": {
-          "$ref": "#/definitions/key",
+          "$ref": "#/definitions/groupStep/key",
           "deprecated": true,
         },
         "label": {

--- a/schema.json
+++ b/schema.json
@@ -1242,7 +1242,7 @@
           "$ref": "#/definitions/key"
         },
         "identifier": {
-          "$ref": "#/definitions/triggerStep/proprties/key"
+          "$ref": "#/definitions/triggerStep/properties/key"
         },
         "id": {
           "$ref": "#/definitions/triggerStep/properties/key",


### PR DESCRIPTION
- Make `id` and `identifier` use a reference the `key` property of the same type
  - This is kind of a a "hint" its an alias
  - There's some prior art already with `commandStep/commands` pointing to `commandStep/command`
- Add a "not UUID" regex to the `key` definitions
  - FWIW I tried a few non-UUID-but-same-pattern (e.g. using colons or the letter H) `key` and BK was cool with it (leading me to believe that it is looking for a regex similar to this one)
- (Happy to undo) mark `id` as `deprecated`
- Shuffled the order so `id`/`identifier` are after `key`

Fixes #76