### PR TITLE
Make `exit_status` types `integer`s

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -61,11 +61,11 @@
               "enum": [ "*" ]
             },
             {
-              "type": "number"
+              "type": "integer"
             },
             {
               "type": "array",
-              "items": { "type": "number" }
+              "items": { "type": "integer" }
             }
           ]
         },
@@ -540,7 +540,7 @@
                         "enum": [ "*" ]
                       },
                       {
-                        "type": "number"
+                        "type": "integer"
                       }
                     ]
                   }


### PR DESCRIPTION
`number` includes floating point, as per the [JSON Schema](https://json-schema.org/understanding-json-schema/reference/numeric), which isn't applicable to exit codes