### PR TITLE
Flatten `#/definitions/groupStep/properties/type/type`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1339,7 +1339,7 @@
           "minSize": 1
         },
         "type": {
-          "type": [ "string" ],
+          "type": "string",
           "enum": [ "group" ]
         }
       },


### PR DESCRIPTION
Was a list-of-one-string, but flattened to single string