### PR TITLE
Use `minItems` instead of `minSize`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1336,7 +1336,7 @@
               { "$ref": "#/definitions/nestedWaitStep" }
             ]
           },
-          "minSize": 1
+          "minItems": 1
         },
         "type": {
           "type": [ "string" ],


### PR DESCRIPTION
`minItems` is documented in the [Schema](https://json-schema.org/understanding-json-schema/reference/array#length), not sure about `minSize` 😅 