### PR TITLE
Move `trigger` requirement to `triggerStep` (Fix #94)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1230,10 +1230,7 @@
               ]
             }
           },
-          "additionalProperties": false,
-          "required": [
-            "trigger"
-          ]
+          "additionalProperties": false
         },
         "depends_on": {
           "$ref": "#/definitions/dependsOn"
@@ -1271,7 +1268,10 @@
           "$ref": "#/definitions/softFail"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "trigger"
+      ]
     },
     "nestedTriggerStep": {
       "type": "object",


### PR DESCRIPTION
This fixes the CI failure introduced in https://github.com/buildkite/pipeline-schema/pull/94
(Somehow CI isn't running pre-merge 😢 )

The `required` prop was accidentally added to `triggerStep/build` instead of `triggerStep`
