### PR TITLE
Add label/name to WaitStep

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1136,6 +1136,7 @@
         },
         "name": {
           "$ref": "#/definitions/label"
+        },
         "identifier": {
           "$ref": "#/definitions/waitStep/properties/key"
         },

--- a/schema.json
+++ b/schema.json
@@ -1138,6 +1138,12 @@
         "key": {
           "$ref": "#/definitions/key"
         },
+        "label": {
+          "$ref": "#/definitions/label"
+        },
+        "name": {
+          "$ref": "#/definitions/label"
+        },
         "type": {
           "type": "string",
           "enum": [ "wait", "waiter" ]


### PR DESCRIPTION
It's not documented. It's also pretty useless. But it's also supported!

(And FWIW this now means all steps have `label` and `name` properties in the schema)