### PR TITLE
avoid negative lookahead assertion in identifier pattern

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -207,7 +207,9 @@
       "type": "string",
       "description": "A unique identifier for a step, must not resemble a UUID",
       "examples": [ "deploy-staging", "test-integration" ],
-      "pattern": "^(?!^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$).*$"
+      "not": {
+        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      }
     },
     "label": {
       "type": "string",


### PR DESCRIPTION
The latest version of the JSON Schema specification mentions the fact that there are many different regular expression variants and says:

> given the high disparity in regular expression constructs support,
> schema authors SHOULD limit themselves to the following regular expression tokens:

(See https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#name-regular-expressions)

One example of such a variant is Go's regular expression evaluator which, despite, and in fact because of, some limitations, such as no backreferences or lookahead, has some technical advantages such as a guaranteed non-exponential runtime (see https://swtch.com/~rsc/regexp/regexp1.html for some background).

Our JSON Schema checker uses that implementation for matching regular expressions, which means that it cannot check the regular expressions in `schema.json` that contain negative lookahead assertions.

Given the above, this PR changes the schema to avoid using a negative lookahead assertion, which is straightforward to do (and arguably more intuitive to understand) by using the `not` keyword.