### PR TITLE
Remove `type` property from `groupStep`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1345,10 +1345,6 @@
             ]
           },
           "minItems": 1
-        },
-        "type": {
-          "type": "string",
-          "enum": [ "group" ]
         }
       },
       "required": ["steps"],

--- a/test/valid-pipelines/group.yml
+++ b/test/valid-pipelines/group.yml
@@ -5,11 +5,6 @@ steps:
     steps:
       - command: test
 
-  - type: "group"
-    label: "Tests"
-    steps:
-      - command: test
-
   # Null group name
 
   - group: ~
@@ -26,11 +21,6 @@ steps:
 
   - group: "Tests"
     identifier: "an-id"
-    steps:
-      - command: test
-
-  - type: "group"
-    name: "Tests"
     steps:
       - command: test
 


### PR DESCRIPTION
Using:

```yaml
steps:
    - group: ~
       type: group
       steps:
           - command: hi 
```

I get:
```
`type` is not a valid property on a step group
```

(note I also think this is a typo and maybe the error means "group step"?)