### PR TITLE
Make `group` property required in `GroupStep`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1351,7 +1351,7 @@
           "enum": [ "group" ]
         }
       },
-      "required": ["steps"],
+      "required": ["group", "steps"],
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
According to the [docs](https://buildkite.com/docs/pipelines/configure/step-types/group-step) `group` is required.

FWIW there's no way to really test this out, since the following pipeline gives a "missing type" error and defining `type: group` also [doesn't work](https://github.com/buildkite/pipeline-schema/pull/103).

```yaml
steps:
    - label: group label 
      steps:
        - command: hi
```