### PR TITLE
Remove `waiter` as a property of `waitStep`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1135,9 +1135,6 @@
         "wait": {
           "description": "Waits for previous steps to pass before continuing",
           "type": ["string", "null"]
-        },
-        "waiter": {
-          "type": ["string", "null"]
         }
       },
       "additionalProperties": false

--- a/test/valid-pipelines/wait.yml
+++ b/test/valid-pipelines/wait.yml
@@ -12,9 +12,6 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - waiter: ~
-    continue_on_failure: true
-
   - wait:
       continue_on_failure: true
 


### PR DESCRIPTION
Not sure what this is, but:

```yaml
steps:
    - waiter: foobarbaz
```

gives me <code>\`waiter\` is not a valid property on the \`wait\` step, perhaps you meant \`wait\`?</code>

---
Note the following pipelines are valid (hence not removing _all_ instances of `"waiter"`):

```yaml
steps:
    - "waiter"
```

```yaml
steps:
    - type: waiter
```

```yaml
steps:
    - waiter:
          wait: ~
```