### PR TITLE
Simplify "bool-or-bool-like-string" to just use `enum`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1045,12 +1045,12 @@
                   "type": "object",
                   "properties": {
                     "allowed": {
-                      "enum": [true, false, "true", "false"]
+                      "enum": [true, false, "true", "false"],
                       "description": "Whether or not this job can be retried manually",
                       "default": true
                     },
                     "permit_on_passed": {
-                      "enum": [true, false, "true", "false"]
+                      "enum": [true, false, "true", "false"],
                       "description": "Whether or not this job can be retried after it has passed",
                       "default": true
                     },

--- a/schema.json
+++ b/schema.json
@@ -1015,8 +1015,7 @@
             "automatic": {
               "anyOf": [
                 {
-                  "type": ["boolean", "string"],
-                  "pattern": "^(true|false)$"
+                  "enum": [true, false, "true", "false"]
                 },
                 {
                   "$ref": "#/definitions/automaticRetry"
@@ -1040,21 +1039,18 @@
               "description": "Whether to allow a job to be retried manually",
               "anyOf": [
                 {
-                  "type": ["boolean", "string"],
-                  "pattern": "^(true|false)$"
+                  "enum": [true, false, "true", "false"]
                 },
                 {
                   "type": "object",
                   "properties": {
                     "allowed": {
-                      "type": ["boolean", "string"],
-                      "pattern": "^(true|false)$",
+                      "enum": [true, false, "true", "false"]
                       "description": "Whether or not this job can be retried manually",
                       "default": true
                     },
                     "permit_on_passed": {
-                      "type": ["boolean", "string"],
-                      "pattern": "^(true|false)$",
+                      "enum": [true, false, "true", "false"]
                       "description": "Whether or not this job can be retried after it has passed",
                       "default": true
                     },


### PR DESCRIPTION
From https://json-schema.org/understanding-json-schema/reference/enum#enumerated-values

> You can use enum even without a type, to accept values of different types.

IMHO this makes the intent much more obvious (and avoids regular expressions!)