### PR TITLE
Revert "Use `"format": "uuid"` instead of a regex"

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -208,7 +208,7 @@
       "description": "A unique identifier for a step, must not resemble a UUID",
       "examples": [ "deploy-staging", "test-integration" ],
       "not": {
-        "format": "uuid"
+        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
       }
     },
     "label": {


### PR DESCRIPTION
Reverts buildkite/pipeline-schema#109