### PR TITLE
Give `continue_on_failure` a default

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1118,7 +1118,8 @@
         },
         "continue_on_failure": {
           "description": "Continue to the next steps, even if the previous group of steps fail",
-          "enum": [true, false, "true", "false"]
+          "enum": [true, false, "true", "false"],
+          "default": false
         },
         "depends_on": {
           "$ref": "#/definitions/dependsOn"


### PR DESCRIPTION
All the other boolean fields have a default and this one is JEALOUS