### PR TITLE
Input `select` `options` can't be empty

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -443,6 +443,7 @@
                 },
               "options": {
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {


### PR DESCRIPTION
```
`options` can't be empty
```