### PR TITLE
Set the `default` for `blocked_state`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -557,6 +557,7 @@
         },
         "blocked_state": {
           "type": "string",
+          "default": "passed",
           "description": "The state that the build is set to when the build is blocked by this block step",
           "enum": [ "passed", "failed", "running" ]
         },


### PR DESCRIPTION
From [the docs](https://buildkite.com/docs/pipelines/configure/step-types/block-step):

> [...] Default: passed [...]