### PR TITLE
`trigger` step `soft_fail` can only be a bool

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1264,7 +1264,9 @@
           "$ref": "#/definitions/skip"
         },
         "soft_fail": {
-          "$ref": "#/definitions/softFail"
+          "enum": [true, false, "true", "false"],
+          "description": "The conditions for marking the step as a soft-fail.",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
```yaml
steps:
  - trigger: trigger
    soft_fail:
      exit_status: "*"
```

results in "The `soft_fail` ruleset on a `trigger` step must either be `true` or `false`"

but the following is OK:
```yaml
steps:
  - trigger: trigger
    soft_fail: "false"

```