### PR TITLE
Remove the `github_check` object properties from notification options

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -326,15 +326,7 @@
             "properties": {
               "github_check": {
                 "type": "object",
-                "properties": {
-                  "context": {
-                    "description": "GitHub commit status name",
-                    "type": "string"
-                  }
-                }
-              },
-              "if": {
-                "$ref": "#/definitions/if"
+                "additionalProperties": false
               }
             },
             "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -325,8 +325,7 @@
             "type": "object",
             "properties": {
               "github_check": {
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "additionalProperties": false
@@ -949,8 +948,7 @@
                 "type": "object",
                 "properties": {
                   "github_check": {
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
                 "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -952,6 +952,10 @@
                   }
                 },
                 "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "additionalProperties": false
               }
             ]
           }

--- a/schema.json
+++ b/schema.json
@@ -955,6 +955,12 @@
               },
               {
                 "type": "object",
+                "properties": {
+                  "github_check": {
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
                 "additionalProperties": false
               }
             ]

--- a/schema.json
+++ b/schema.json
@@ -952,24 +952,6 @@
                   }
                 },
                 "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "github_check": {
-                    "type": "object",
-                    "properties": {
-                      "context": {
-                        "description": "GitHub commit status name",
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "if": {
-                    "$ref": "#/definitions/if"
-                  }
-                },
-                "additionalProperties": false
               }
             ]
           }


### PR DESCRIPTION
It seems `github_check` [got renamed to `github_commit_status`](https://github.com/buildkite/docs/pull/1371), however, only the string `github_commit_status` got an alias.

```yaml
steps:
  - command: command
notify:
  - github_check:
      context: foo
```

Lands me "`context` is an not a valid `github_check` option"

(as does)
```yaml
steps:
  - command: command
notify:
  - github_check:
       if: thing
```

("`if` is an not a valid `github_check` option")

but note this is OK:

```yaml
steps:
  - command: command
notify:
  - github_check:
```

so its still an object