### PR TITLE
Disallow extra props for `github_commit_status`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -313,7 +313,8 @@
                     "description": "GitHub commit status name",
                     "type": "string"
                   }
-                }
+                },
+                "additionalProperties": false
               },
               "if": {
                 "$ref": "#/definitions/if"
@@ -945,7 +946,8 @@
                         "description": "GitHub commit status name",
                         "type": "string"
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   },
                   "if": {
                     "$ref": "#/definitions/if"


### PR DESCRIPTION
Both of these fail with "`foo` is an not a valid `github_commit_status` option"

```yaml
steps:
  - command: command
notify:
  - github_commit_status:
      context: foo
      foo: bar
```

```yaml
steps:
  - command: command
    notify:
      - github_commit_status:
          context: foo
          foo: bar
```