### PR TITLE
Disallow extra props for `slack`'s config

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -925,7 +925,8 @@
                           "message": {
                             "type": "string"
                           }
-                        }
+                        },
+                        "additionalProperties": false
                       }
                     ]
                   },


### PR DESCRIPTION
Both of these fail with "foo is an not a valid `slack` option"

```yaml
steps:
  - command: command
    notify:
      - slack:
          message: hey
          foo: bar
```

```yaml
steps:
  - command: command
notify:
  - slack:
      message: hey
      foo: bar
```