### PR TITLE
Disallow extra props for `retry`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1068,7 +1068,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         "skip": {
           "$ref": "#/definitions/skip"


### PR DESCRIPTION
This fails with "`foo` is not a valid property on the retry ruleset. Please check the documentation to get a full list of supported properties."

```yaml
steps:
  - command: command
    retry:
      foo: bar
```