### PR TITLE
Disallow extra props for matrix's adjustment's `with`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -873,7 +873,8 @@
                         "$ref": "#/definitions/softFail"
                       }
                     },
-                    "required": ["with"]
+                    "required": ["with"],
+                    "additionalProperties": false
                   }
                 }
               },


### PR DESCRIPTION
Both of these fail with "`foo` is not a valid property on the `matrix.adjustments` configuration. Please check the documentation to get a full list of supported properties."


```yaml
steps:
  - command: command
    matrix:
      setup:
        test:
          - "A"
          - "B"
      adjustments:
        - with:
            test: "B"
          foo: bar
```