### PR TITLE
Disallow extra props for `matrix`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -877,7 +877,8 @@
                   }
                 }
               },
-              "required": ["setup"]
+              "required": ["setup"],
+              "additionalProperties": false
             }
           ]
         },


### PR DESCRIPTION
This fails with "`foo` is not a valid property on the `matrix` configuration. Please check the documentation to get a full list of supported properties."

```yaml
steps:
  - command: command
    matrix:
      setup:
        test:
          - "A"
          - "B"
      adjustments:
        - with:
            test: "B"
      foo: bar
```