### PR TITLE
Add `default` to "manual"

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1066,7 +1066,8 @@
                   },
                   "additionalProperties": false
                 }
-              ]
+              ],
+              "default": true
             }
           }
         },


### PR DESCRIPTION
According to https://buildkite.com/docs/pipelines/configure/step-types/command-step#retry-attributes the default is `true`