### PR TITLE
Restrict `with`'s first type to be `string`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -845,9 +845,8 @@
                       "with": {
                         "oneOf": [
                           {
-                            "type": "array",
+                            "type": "string",
                             "description": "List of existing or new elements for single-dimension Build Matrix",
-                            "items": { "$ref": "#/definitions/matrixElement" }
                           },
                           {
                             "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -846,7 +846,7 @@
                         "oneOf": [
                           {
                             "type": "string",
-                            "description": "List of existing or new elements for single-dimension Build Matrix",
+                            "description": "An existing or new element for single-dimension Build Matrix",
                           },
                           {
                             "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -846,7 +846,7 @@
                         "oneOf": [
                           {
                             "type": "string",
-                            "description": "An existing or new element for single-dimension Build Matrix",
+                            "description": "An existing or new element for single-dimension Build Matrix"
                           },
                           {
                             "type": "object",


### PR DESCRIPTION
The following pipeline errors with "Each element in a `matrix.adjustments.with` must be either a hash or a string":

```yaml
steps:
  - label: "💥 Matrix build with adjustments"
    command: "echo"
    matrix:
      setup:
        - "2"
      adjustments:
        - with:
            - "2"
          soft_fail: true
```