### PR TITLE
`cache:` `paths` isn't allowed to be a string

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -131,13 +131,10 @@
           "type": "object",
           "properties": {
             "paths": {
-              "anyOf": [
-                { "type": "string" },
-                {
-                  "type": "array",
-                  "items": { "type": "string" }
-                }
-              ]
+              "anyOf": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
             },
             "size": {
               "type": "string",
@@ -701,9 +698,6 @@
         },
         "branches": {
           "$ref": "#/definitions/branches"
-        },
-        "cache": {
-          "$ref": "#/definitions/cache"
         },
         "cache": {
           "$ref": "#/definitions/cache"


### PR DESCRIPTION
The following pipeline gives me "`paths` must be an Array"

```yaml
steps:
  - command: command
    cache:
      paths: "node_modules"
      size: "100g"
```