### PR TITLE
Fix `skip` description

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -510,7 +510,7 @@
         { "type": "boolean" },
         { "type": "string" }
       ],
-      "description": "Whether this step should be skipped. You can specify a reason for using a string.",
+      "description": "Whether this step should be skipped. Passing a string provides a reason for skipping this command",
       "examples": [
         true,
         false,


### PR DESCRIPTION
(grammar was weird. I just copied from the docs)
(also note I tried passing a `skip` string thats 80 characters and it worked, so I didn't copy the length restriction the docs claim)