### PR TITLE
DIsentangle `matrix` into 3 types

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -801,38 +801,14 @@
             },
             {
               "type": "object",
-              "description": "Configuration for multi-dimension Build Matrix",
+              "description": "Configuration for single-dimension Build Matrix",
               "properties": {
                 "setup": {
-                  "oneOf": [
-                    {
-                      "type": "array",
-                      "description": "List of elements for single-dimension Build Matrix",
-                      "items": { "$ref": "#/definitions/matrixElement" },
-                      "examples": [
-                        ["linux", "freebsd"]
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "description": "Mapping of Build Matrix dimension names to their lists of elements",
-                      "propertyNames": {
-                        "type": "string",
-                        "description": "Build Matrix dimension name",
-                        "pattern": "^[a-zA-Z0-9_]+$"
-                      },
-                      "additionalProperties": {
-                        "type": "array",
-                        "description": "List of elements for this Build Matrix dimension",
-                        "items": { "$ref": "#/definitions/matrixElement" }
-                      },
-                      "examples": [
-                        {
-                          "os": ["linux", "freebsd"],
-                          "arch": ["arm64", "riscv"]
-                        }
-                      ]
-                    }
+                  "type": "array",
+                  "description": "List of elements for single-dimension Build Matrix",
+                  "items": { "$ref": "#/definitions/matrixElement" },
+                  "examples": [
+                    ["linux", "freebsd"]
                   ]
                 },
                 "adjustments": {
@@ -843,27 +819,69 @@
                     "description": "An adjustment to a Build Matrix",
                     "properties": {
                       "with": {
-                        "oneOf": [
-                          {
-                            "type": "array",
-                            "description": "List of existing or new elements for single-dimension Build Matrix",
-                            "items": { "$ref": "#/definitions/matrixElement" }
-                          },
-                          {
-                            "type": "object",
-                            "description": "Specification of a new or existing Build Matrix combination",
-                            "propertyNames": {
-                              "type": "string",
-                              "description": "Build Matrix dimension name"
-                            },
-                            "additionalProperties": {
-                              "type": "string",
-                              "description": "Build Matrix dimension element"
-                            },
-                            "examples": [
-                              { "os": "linux", "arch": "arm64" }
-                            ]
-                          }
+                        "type": "string",
+                        "description": "An existing or new element for single-dimension Build Matrix",
+                      },
+                      "skip": {
+                        "$ref": "#/definitions/skip"
+                      },
+                      "soft_fail": {
+                        "$ref": "#/definitions/softFail"
+                      }
+                    },
+                    "required": ["with"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["setup"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "description": "Configuration for multi-dimension Build Matrix",
+              "properties": {
+                "setup": {
+                    "type": "object",
+                    "description": "Mapping of Build Matrix dimension names to their lists of elements",
+                    "propertyNames": {
+                      "type": "string",
+                      "description": "Build Matrix dimension name",
+                      "pattern": "^[a-zA-Z0-9_]+$"
+                    },
+                    "additionalProperties": {
+                      "type": "array",
+                      "description": "List of elements for this Build Matrix dimension",
+                      "items": { "$ref": "#/definitions/matrixElement" }
+                    },
+                    "examples": [
+                      {
+                        "os": ["linux", "freebsd"],
+                        "arch": ["arm64", "riscv"]
+                      }
+                    ]
+                  }
+                },
+                "adjustments": {
+                  "type": "array",
+                  "description": "List of Build Matrix adjustments",
+                  "items": {
+                    "type": "object",
+                    "description": "An adjustment to a Build Matrix",
+                    "properties": {
+                      "with": {
+                        "type": "object",
+                        "description": "Specification of a new or existing Build Matrix combination",
+                        "propertyNames": {
+                          "type": "string",
+                          "description": "Build Matrix dimension name"
+                        },
+                        "additionalProperties": {
+                          "type": "string",
+                          "description": "Build Matrix dimension element"
+                        },
+                        "examples": [
+                          { "os": "linux", "arch": "arm64" }
                         ]
                       },
                       "skip": {
@@ -873,11 +891,13 @@
                         "$ref": "#/definitions/softFail"
                       }
                     },
-                    "required": ["with"]
+                    "required": ["with"],
+                    "additionalProperties": false
                   }
                 }
               },
-              "required": ["setup"]
+              "required": ["setup"],
+              "additionalProperties": false
             }
           ]
         },


### PR DESCRIPTION
Having poked through the docs and trying to upload several pipelines, it really seems like there's 3 `matrix` types:

1. Just a list of elements
2. A `setup` list of elements with adjustments (which are strings)
3. A `setup` mapping with adjustments (which are objects)

So, disentangled the definitions to reflect the 3 types