### PR TITLE
[bug] AnyOf in `paths` must be an array. Use an object instead

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -131,10 +131,8 @@
           "type": "object",
           "properties": {
             "paths": {
-              "anyOf": {
-                "type": "array",
-                "items": { "type": "string" }
-              }
+              "type": "array",
+              "items": { "type": "string" }
             },
             "size": {
               "type": "string",


### PR DESCRIPTION
A recent change (https://github.com/buildkite/pipeline-schema/pull/126/files) introduced invalid schema for `paths`

With the change made, `paths` is now only allowed to be an array with strings for items. `anyOf` was updated to be an object representing the schema of `paths` but this must only be an array.

`anyOf` is no longer required as it's only a single allowed type.