### PR TITLE
add optional attribute blocked_state to input step

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -634,6 +634,12 @@
         "fields": {
           "$ref": "#/definitions/fields"
         },
+        "blocked_state": {
+          "type": "string",
+          "default": "passed",
+          "description": "The state that the build is set to when the build is blocked by this input step",
+          "enum": ["passed", "failed", "running"]
+        },
         "if": {
           "$ref": "#/definitions/if"
         },


### PR DESCRIPTION
Input steps allow `blocked_state` as an optional attribute, so it should be reflected in the schema.