### PR TITLE
Add environment variable support for parallelism field

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -25,6 +25,27 @@
       "description": "Whether to proceed with this step and further steps if a step named in the depends_on attribute fails",
       "default": false
     },
+    "envVarString": {
+      "type": "string",
+      "description": "An environment variable reference that will be substituted at runtime",
+      "pattern": "^\\$[A-Z_][A-Z0-9_]*$",
+      "examples": [
+        "$PARALLELISM",
+        "$NUMBER_OF_JOBS"
+      ]
+    },
+    "integerOrEnvVar": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "description": "A literal integer value"
+        },
+        {
+          "$ref": "#/definitions/envVarString"
+        }
+      ],
+      "description": "Either an integer value or an environment variable reference"
+    },
     "agents": {
       "oneOf": [
         { "$ref": "#/definitions/agentsObject" },
@@ -954,10 +975,11 @@
           }
         },
         "parallelism": {
-          "type": "integer",
+          "$ref": "#/definitions/integerOrEnvVar",
           "description": "The number of parallel jobs that will be created based on this step",
           "examples": [
-            42
+            42,
+            "$PARALLELISM"
           ]
         },
         "plugins": {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -48,6 +48,9 @@ describe('schema.json', function() {
   it('should validate matrix', function() {
     validate('matrix.yml')
   })
+  it('should validate environment variables in parallelism field', function() {
+    validate('parallelism-env-vars.yml')
+  })
   
   it('should verify groupStep.steps uses the same-ish items as root steps', function () {
     const mainList = schema.properties.steps.items.anyOf

--- a/test/valid-pipelines/parallelism-env-vars.yml
+++ b/test/valid-pipelines/parallelism-env-vars.yml
@@ -1,0 +1,16 @@
+steps:
+  # Test parallelism with environment variable
+  - command: "echo 'Testing parallelism with env var'"
+    parallelism: $PARALLELISM
+
+  # Test parallelism with literal value
+  - command: "echo 'Testing parallelism with literal'"
+    parallelism: 5
+
+  # Test mixed usage (parallelism with env var, other properties with literals)
+  - command: "echo 'Testing mixed configuration'"
+    parallelism: $PARALLELISM
+    concurrency: 2
+    concurrency_group: "test-group"
+    timeout_in_minutes: 30
+    priority: 1


### PR DESCRIPTION
- Add envVarString and integerOrEnvVar schema definitions
- Update parallelism field to accept environment variables using $VAR syntax
- Add test for valid environment variable patterns in parallelism field

fixes #79