### PR TITLE
Expand signal reasons for stack errors

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -104,11 +104,13 @@
           "enum": [
             "*",
             "none",
+            "agent_incompatible",
             "agent_refused",
             "agent_stop",
             "cancel",
             "process_run_error",
-            "signature_rejected"
+            "signature_rejected",
+            "stack_error"
           ]
         }
       },
@@ -508,7 +510,10 @@
           "items": {
             "type": "string"
           },
-          "examples": [["**.go", "go.{mod,sum}"], ["app/**", "spec/**"]]
+          "examples": [
+            ["**.go", "go.{mod,sum}"],
+            ["app/**", "spec/**"]
+          ]
         },
         {
           "type": "object",


### PR DESCRIPTION
## Description

As per [the docs](https://buildkite.com/docs/pipelines/configure/step-types/command-step#retry-attributes-automatic-retry-attributes), we now have `agent_incompatible` and `stack_error` as possible `signal_reason` attributes for command retries.
