### PR TITLE
Add checkout depth

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -179,9 +179,14 @@
         "skip": {
           "type": "boolean",
           "description": "Skip the git checkout phase. An explicit false is preserved and is not equivalent to omitting the field; at pipeline level, false re-enables checkout for steps that would otherwise inherit a pipeline-level true."
+        },
+        "depth": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Shallow clone depth. Limits git history to the most recent N commits. Requires git 1.9 or newer."
         }
       },
-      "examples": [{ "skip": true }]
+      "examples": [{ "skip": true }, { "depth": 10 }]
     },
     "dependsOnList": {
       "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -176,15 +176,16 @@
       "type": "object",
       "description": "Configure git checkout behavior. When set pipeline-wide, it applies to all steps that do not have their own checkout key set",
       "properties": {
+        "depth": {
+          "type": "integer",
+          "description": "Number of commits to fetch when performing a shallow clone; omit for full history",
+          "minimum": 1,
+          "examples": [1]
+        },
         "skip": {
           "enum": [true, false, "true", "false"],
           "description": "Skip the git checkout phase",
           "default": false
-        },
-        "depth": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Shallow clone depth, limits git history to the most recent N commits"
         }
       },
       "additionalProperties": false

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -107,6 +107,24 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should reject checkout.depth of zero", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { depth: 0 } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.depth as a string", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { depth: "10" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should verify groupStep.steps uses the same-ish items as root steps", function () {
     const mainList = schema.definitions.pipelineSteps.items.anyOf;
     const groupList = schema.definitions.groupSteps.items.anyOf;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -163,6 +163,15 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should accept checkout.depth", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { depth: 10 } }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
   it("should reject checkout.depth of zero", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
@@ -177,6 +186,26 @@ describe("schema.json", function () {
     const v = ajv.compile(schema);
     const pipeline = {
       steps: [{ command: "echo hello", checkout: { depth: "10" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept pipeline-level checkout.depth", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { depth: 10 },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject pipeline-level checkout.depth of zero", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { depth: 0 },
+      steps: [{ command: "echo hello" }],
     };
     expect(v(pipeline)).to.eql(false);
   });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -181,11 +181,29 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should reject checkout.depth as a negative integer", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { depth: -1 } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should reject checkout.depth as a string", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
     const pipeline = {
       steps: [{ command: "echo hello", checkout: { depth: "10" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.depth as a float", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { depth: 1.5 } }],
     };
     expect(v(pipeline)).to.eql(false);
   });

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -13,3 +13,7 @@ steps:
 
   - command: echo "step-level only, empty object"
     checkout: {}
+
+  - command: echo "shallow clone"
+    checkout:
+      depth: 10

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -1,5 +1,6 @@
 checkout:
   skip: true
+  depth: 50
 
 steps:
   - command: test


### PR DESCRIPTION
* Adds `depth` integer property to the shared `checkout` definition
* Adds rejection tests for `depth: 0` and `depth: "10"` to match the rest of the codebase, even when bk/bk accepts integers as strings
* Adds a `depth: 10` step to the `checkout.yml`

Branched off of PR https://github.com/buildkite/pipeline-schema/pull/160

Backend support is the open PR [https://github.com/buildkite/buildkite/pull/29615](https://github.com/buildkite/buildkite/pull/29615).