### PR TITLE
Add checkout commit verification to pipeline schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -179,9 +179,14 @@
         "skip": {
           "type": "boolean",
           "description": "Skip the git checkout phase. An explicit false is preserved and is not equivalent to omitting the field; at pipeline level, false re-enables checkout for steps that would otherwise inherit a pipeline-level true."
+        },
+        "commit_verification": {
+          "type": "string",
+          "enum": ["strict", "warn"],
+          "description": "Verify that the commit being checked out exists on the expected branch. 'strict' fails the job if the commit is provably not on the branch; infrastructure failures are logged as warnings. 'warn' logs a warning on any verification failure but never fails the job. Omitting this field disables verification."
         }
       },
-      "examples": [{ "skip": true }]
+      "examples": [{ "skip": true }, { "commit_verification": "strict" }]
     },
     "dependsOnList": {
       "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -189,8 +189,8 @@
         },
         "commit_verification": {
           "type": "string",
-          "enum": ["strict", "warn"],
-          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive verification failure, warn only logs"
+          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive verification failure, warn only logs",
+          "enum": ["strict", "warn"]
         }
       },
       "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -184,7 +184,7 @@
         },
         "skip": {
           "enum": [true, false, "true", "false"],
-          "description": "Skip the git checkout phase. An explicit false is preserved and is not equivalent to omitting the field; at pipeline level, false re-enables checkout for steps that would otherwise inherit a pipeline-level true.",
+          "description": "Skip the git checkout phase",
           "default": false
         },
         "commit_verification": {

--- a/schema.json
+++ b/schema.json
@@ -189,7 +189,7 @@
         },
         "commit_verification": {
           "type": "string",
-          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive verification failure, warn only logs",
+          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive mismatch, warn only logs",
           "enum": ["strict", "warn"]
         }
       },

--- a/schema.json
+++ b/schema.json
@@ -190,7 +190,7 @@
         "commit_verification": {
           "type": "string",
           "enum": ["strict", "warn"],
-          "description": "Verify that the commit being checked out exists on the expected branch. 'strict' fails the job if the commit is provably not on the branch; infrastructure failures are logged as warnings. 'warn' logs a warning on any verification failure but never fails the job. Omitting this field disables verification."
+          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive verification failure, warn only logs"
         }
       },
       "additionalProperties": false

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -107,6 +107,59 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should accept checkout.commit_verification with 'strict'", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { commit_verification: "strict" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should accept checkout.commit_verification with 'warn'", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { commit_verification: "warn" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject checkout.commit_verification with an invalid string value", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { commit_verification: "error" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.commit_verification with a boolean value", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { commit_verification: true } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.commit_verification with an integer value", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { commit_verification: 1 } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should verify groupStep.steps uses the same-ish items as root steps", function () {
     const mainList = schema.definitions.pipelineSteps.items.anyOf;
     const groupList = schema.definitions.groupSteps.items.anyOf;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -281,6 +281,26 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should accept pipeline-level checkout.commit_verification", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { commit_verification: "strict" },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject pipeline-level checkout.commit_verification with an invalid value", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { commit_verification: "error" },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should verify groupStep.steps uses the same-ish items as root steps", function () {
     const mainList = schema.definitions.pipelineSteps.items.anyOf;
     const groupList = schema.definitions.groupSteps.items.anyOf;

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -3,6 +3,7 @@
 # Pipeline-level checkout applies to every step unless the step overrides it
 checkout:
   skip: true
+  commit_verification: "strict"
 
 steps:
   - command: echo "inherits pipeline-level checkout.skip"
@@ -13,3 +14,16 @@ steps:
 
   - command: echo "step-level only, empty object"
     checkout: {}
+
+  - command: echo "commit verification strict"
+    checkout:
+      commit_verification: "strict"
+
+  - command: echo "commit verification warn"
+    checkout:
+      commit_verification: "warn"
+
+  - command: echo "skip false with strict verification"
+    checkout:
+      skip: false
+      commit_verification: "strict"

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -17,20 +17,20 @@ steps:
     checkout:
       depth: 10
 
-  - command: echo "commit verification strict"
+  - command: test
     checkout:
       commit_verification: "strict"
 
-  - command: echo "commit verification warn"
+  - command: test
     checkout:
       commit_verification: "warn"
 
-  - command: echo "skip false with strict verification"
+  - command: test
     checkout:
       skip: false
       commit_verification: "strict"
 
-  - command: echo "depth with strict verification"
+  - command: test
     checkout:
       depth: 10
       commit_verification: "strict"

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -29,3 +29,8 @@ steps:
     checkout:
       skip: false
       commit_verification: "strict"
+
+  - command: echo "depth with strict verification"
+    checkout:
+      depth: 10
+      commit_verification: "strict"

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -215,3 +215,16 @@ steps:
 
   - command: test
     checkout: {}
+
+  - command: test
+    checkout:
+      commit_verification: "strict"
+
+  - command: test
+    checkout:
+      commit_verification: "warn"
+
+  - command: test
+    checkout:
+      skip: false
+      commit_verification: "strict"


### PR DESCRIPTION
Extends the `checkout` definition to add support for a 'commit_verification' attribute.