### PR TITLE
Add `checkout.sparse` to schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -179,9 +179,26 @@
         "skip": {
           "type": "boolean",
           "description": "Skip the git checkout phase. An explicit false is preserved and is not equivalent to omitting the field; at pipeline level, false re-enables checkout for steps that would otherwise inherit a pipeline-level true."
+        },
+        "sparse": {
+          "type": "object",
+          "description": "Enable sparse checkout - only check out specified paths (requires git 2.25+, cone mode).",
+          "properties": {
+            "paths": {
+              "type": "array",
+              "description": "List of directory paths to include in the sparse checkout (cone mode)",
+              "items": { "type": "string" },
+              "minItems": 1
+            }
+          },
+          "required": ["paths"],
+          "additionalProperties": false
         }
       },
-      "examples": [{ "skip": true }]
+      "examples": [
+        { "skip": true },
+        { "sparse": { "paths": ["src/", "docs/"] } }
+      ]
     },
     "dependsOnList": {
       "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -187,25 +187,6 @@
           "description": "Skip the git checkout phase",
           "default": false
         },
-        "sparse": {
-          "type": "object",
-          "description": "Check out only the specified paths (cone mode, requires git 2.26+)",
-          "properties": {
-            "paths": {
-              "type": "array",
-              "description": "Repository-relative directory paths within the worktree",
-              "items": {
-                "type": "string",
-                "minLength": 1,
-                "pattern": "^[^,\\n\\r]+$"
-              },
-              "minItems": 1
-            }
-          },
-          "required": ["paths"],
-          "additionalProperties": false,
-          "examples": [{ "paths": ["src/", "docs/"] }]
-        },
         "submodules": {
           "enum": [true, false, "true", "false"],
           "description": "Initialize, sync, update, and clean submodules recursively as part of checkout",
@@ -256,6 +237,26 @@
           "enum": [true, false, "true", "false"],
           "description": "Whether to install Git LFS and fetch LFS objects after checkout",
           "default": false
+        },
+        "sparse": {
+          "type": "object",
+          "description": "Check out only the specified paths in git cone mode; requires git 2.26+ on the agent",
+          "properties": {
+            "paths": {
+              "type": "array",
+              "description": "Repository-relative directory paths within the worktree; cone mode includes each directory recursively, not file globs",
+              "items": {
+                "type": "string",
+                "pattern": "^[^-\\s,]([^,\\n\\r]*[^\\s,])?$"
+              },
+              "minItems": 1,
+              "uniqueItems": true,
+              "examples": [["src/", "docs/"]]
+            }
+          },
+          "required": ["paths"],
+          "additionalProperties": false,
+          "examples": [{ "paths": ["src/", "docs/"] }]
         }
       },
       "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -189,12 +189,16 @@
         },
         "sparse": {
           "type": "object",
-          "description": "Enable sparse checkout, only check out specified paths (requires git 2.25+, cone mode)",
+          "description": "Check out only the specified paths (cone mode, requires git 2.26+)",
           "properties": {
             "paths": {
               "type": "array",
-              "description": "List of directory paths to include in the sparse checkout (cone mode)",
-              "items": { "type": "string" },
+              "description": "Repository-relative directory paths within the worktree",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[^,\\n\\r]+$"
+              },
               "minItems": 1
             }
           },

--- a/schema.json
+++ b/schema.json
@@ -258,7 +258,10 @@
               "description": "Repository-relative directory paths within the worktree; cone mode includes each directory recursively, not file globs",
               "items": {
                 "type": "string",
-                "pattern": "^[^-\\s,]([^,\\n\\r]*[^\\s,])?$"
+                "pattern": "^[^,\\t\\n\\v\\f\\r]+$",
+                "not": {
+                  "pattern": "^[- ]| $"
+                }
               },
               "minItems": 1,
               "uniqueItems": true,

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -107,6 +107,33 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should reject checkout.sparse without paths", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: {} } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with an empty paths array", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: { paths: [] } } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with non-string path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: { paths: [42] } } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should verify groupStep.steps uses the same-ish items as root steps", function () {
     const mainList = schema.definitions.pipelineSteps.items.anyOf;
     const groupList = schema.definitions.groupSteps.items.anyOf;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -854,20 +854,6 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
-  it("should reject checkout.sparse with whitespace-only path items", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [
-        {
-          command: "echo hello",
-          checkout: { sparse: { paths: ["   "] } },
-        },
-      ],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
   it("should reject checkout.sparse with commas in path items", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
@@ -910,6 +896,23 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  // Control whitespace is banned everywhere, not just at the edges: the agent
+  // trims with Go's unicode.IsSpace (which strips tab/VT/FF), so an internal
+  // tab is never a real directory name and could mask a "-flag" once trimmed.
+  it("should reject checkout.sparse with tab characters in path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src\tdocs"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should reject checkout.sparse with duplicate path items", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
@@ -932,6 +935,20 @@ describe("schema.json", function () {
         {
           command: "echo hello",
           checkout: { sparse: { paths: ["src/", "docs/"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should accept checkout.sparse with internal spaces in path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["my dir/"] } },
         },
       ],
     };
@@ -1009,6 +1026,29 @@ describe("schema.json", function () {
         for (const [key, value] of Object.entries(node)) {
           if (key === "pattern" && typeof value === "string") {
             if (lookaround.test(value)) offending.push(value);
+          }
+          walk(value);
+        }
+      }
+    };
+    walk(schema);
+    expect(offending).to.eql([]);
+  });
+
+  // RE2's \s is only [\t\n\f\r ], but ajv's (ECMA) \s also matches \v and many
+  // Unicode spaces, so a \s in a pattern validates differently across the two
+  // engines. Use explicit character classes instead. (\d, \w and friends are
+  // ASCII in both engines, so only \s/\S diverge.)
+  it("should not use \\s or \\S in any pattern", function () {
+    const divergentClass = /\\[sS]/;
+    const offending = [];
+    const walk = (node) => {
+      if (Array.isArray(node)) {
+        node.forEach(walk);
+      } else if (node && typeof node === "object") {
+        for (const [key, value] of Object.entries(node)) {
+          if (key === "pattern" && typeof value === "string") {
+            if (divergentClass.test(value)) offending.push(value);
           }
           walk(value);
         }

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -519,19 +519,26 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
-  it("should validate checkout.flags examples against the schema", function () {
+  it("should validate checkout examples against the schema", function () {
     const ajv = new Ajv({ allErrors: true });
-    const flagsSchema = schema.definitions.checkout.properties.flags;
-    const v = ajv.compile(flagsSchema);
-    for (const example of flagsSchema.examples) {
-      expect(v(example), JSON.stringify(example)).to.eql(true);
-    }
-    for (const [key, subSchema] of Object.entries(flagsSchema.properties)) {
-      const vSub = ajv.compile(subSchema);
+    const checkoutProperties = schema.definitions.checkout.properties;
+    for (const [key, subSchema] of Object.entries(checkoutProperties)) {
+      const v = ajv.compile(subSchema);
       for (const example of subSchema.examples || []) {
-        expect(vSub(example), `${key}: ${JSON.stringify(example)}`).to.eql(
-          true,
-        );
+        expect(v(example), `${key}: ${JSON.stringify(example)}`).to.eql(true);
+      }
+      if (subSchema.properties) {
+        for (const [nestedKey, nestedSchema] of Object.entries(
+          subSchema.properties,
+        )) {
+          const vNested = ajv.compile(nestedSchema);
+          for (const example of nestedSchema.examples || []) {
+            expect(
+              vNested(example),
+              `${key}.${nestedKey}: ${JSON.stringify(example)}`,
+            ).to.eql(true);
+          }
+        }
       }
     }
   });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -612,6 +612,20 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should reject checkout.sparse with whitespace-only path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["   "] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should reject checkout.sparse with commas in path items", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -212,120 +212,6 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
-  it("should reject checkout.sparse without paths", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [{ command: "echo hello", checkout: { sparse: {} } }],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
-  it("should reject checkout.sparse with an empty paths array", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [{ command: "echo hello", checkout: { sparse: { paths: [] } } }],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
-  it("should reject checkout.sparse with non-string path items", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [{ command: "echo hello", checkout: { sparse: { paths: [42] } } }],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
-  it("should reject checkout.sparse with empty-string path items", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [{ command: "echo hello", checkout: { sparse: { paths: [""] } } }],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
-  it("should reject checkout.sparse with commas in path items", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [
-        {
-          command: "echo hello",
-          checkout: { sparse: { paths: ["src,docs"] } },
-        },
-      ],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
-  it("should accept checkout.sparse with paths", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [
-        {
-          command: "echo hello",
-          checkout: { sparse: { paths: ["src/", "docs/"] } },
-        },
-      ],
-    };
-    expect(v(pipeline)).to.eql(true);
-  });
-
-  it("should accept pipeline-level checkout.sparse", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      checkout: { sparse: { paths: ["src/"] } },
-      steps: [{ command: "echo hello" }],
-    };
-    expect(v(pipeline)).to.eql(true);
-  });
-
-  it("should reject pipeline-level checkout.sparse without paths", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      checkout: { sparse: {} },
-      steps: [{ command: "echo hello" }],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
-  it("should accept checkout.sparse on a nested command step", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [
-        {
-          command: {
-            command: "echo hello",
-            checkout: { sparse: { paths: ["src/"] } },
-          },
-        },
-      ],
-    };
-    expect(v(pipeline)).to.eql(true);
-  });
-
-  it("should reject unknown checkout.sparse properties", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [
-        {
-          command: "echo hello",
-          checkout: { sparse: { paths: ["src/"], mode: "no-cone" } },
-        },
-      ],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
   it("should accept checkout.depth", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
@@ -622,6 +508,226 @@ describe("schema.json", function () {
     const v = ajv.compile(schema);
     const pipeline = {
       steps: [{ command: "echo hello", checkout: { lfs: "yes" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse without paths", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: {} } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject non-object checkout.sparse", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: "src/" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with an empty paths array", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: { paths: [] } } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with a non-array paths value", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { sparse: { paths: "src/" } } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with non-string path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: { paths: [42] } } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with empty-string path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: { paths: [""] } } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with leading-dash path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["--no-cone"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  // The agent trims surrounding whitespace before passing paths to git, so a
+  // leading space would let a "-flag" slip past the leading-dash guard.
+  it("should reject checkout.sparse with leading-whitespace path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: [" --no-cone"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with trailing-whitespace path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src/ "] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with commas in path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src,docs"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with newlines in path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src\ndocs"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with carriage returns in path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src\rdocs"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with duplicate path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src/", "src/"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.sparse with paths", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src/", "docs/"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should accept pipeline-level checkout.sparse", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { sparse: { paths: ["src/"] } },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject pipeline-level checkout.sparse without paths", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { sparse: {} },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.sparse on a nested command step", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: {
+            command: "echo hello",
+            checkout: { sparse: { paths: ["src/"] } },
+          },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject unknown checkout.sparse properties", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src/"], unknown: true } },
+        },
+      ],
     };
     expect(v(pipeline)).to.eql(false);
   });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -190,6 +190,93 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should reject checkout.sparse with empty-string path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { sparse: { paths: [""] } } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.sparse with commas in path items", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src,docs"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.sparse with paths", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src/", "docs/"] } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should accept pipeline-level checkout.sparse", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { sparse: { paths: ["src/"] } },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject pipeline-level checkout.sparse without paths", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { sparse: {} },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.sparse on a nested command step", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: {
+            command: "echo hello",
+            checkout: { sparse: { paths: ["src/"] } },
+          },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject unknown checkout.sparse properties", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { sparse: { paths: ["src/"], mode: "no-cone" } },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
   it("should accept checkout.depth", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -13,3 +13,17 @@ steps:
 
   - command: echo "step-level only, empty object"
     checkout: {}
+
+  - command: echo "sparse checkout, single path"
+    checkout:
+      sparse:
+        paths:
+          - src/
+
+  - command: echo "sparse checkout, multiple paths"
+    checkout:
+      sparse:
+        paths:
+          - src/
+          - docs/
+          - test/

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -7,6 +7,10 @@ checkout:
     fetch: "--prune --tags"
     checkout: "--force"
     clean: "-fxd"
+  sparse:
+    paths:
+      - .buildkite/
+      - src/
 
 steps:
   - command: test

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -65,12 +65,6 @@ steps:
       sparse:
         paths:
           - src/
-
-  - command: test
-    checkout:
-      sparse:
-        paths:
-          - src/
           - docs/
           - test/
 

--- a/test/valid-pipelines/command.yml
+++ b/test/valid-pipelines/command.yml
@@ -215,3 +215,10 @@ steps:
 
   - command: test
     checkout: {}
+
+  - command: test
+    checkout:
+      sparse:
+        paths:
+          - src/
+          - docs/


### PR DESCRIPTION
## Summary

Adds a `sparse` object to the shared `checkout` definition, giving pipeline authors per-step (and pipeline-level) control over sparse checkout (cone mode).

`sparse.paths` is a required, non-empty array of unique strings. Each entry is a repository-relative directory included recursively (cone mode, not file globs). Requires `git>=2.26` on the agent.

## Changes

- `schema.json`: add `sparse: { paths: [string, ...] }` to the `checkout` definition (`required: ["paths"]`, `minItems: 1`, `uniqueItems: true`, `additionalProperties: false`). Path strings are validated with `pattern` + `not`: no leading dash (paths are passed positionally to `git sparse-checkout set`), no leading/trailing space, no control characters or commas (the agent transport is comma-delimited). Character classes are explicit rather than `\s`, so they validate identically under ajv and Go's RE2.
- `test/schema.test.js`: positive and negative coverage for the path rules, plus a guard test asserting no pattern uses the `\s`/`\S` shorthand (which diverges between ajv and RE2).
- `test/valid-pipelines/checkout.yml` and `command.yml`: fixture coverage for pipeline-level and step-level single/multi-path cases.

## Validation

- [x] `npm test` (102 passing)
- [x] `npm run format:check`
