### PR TITLE
Sup 6216 add checkout ssh secret

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -235,10 +235,13 @@
         },
         "ssh_secret": {
           "type": "string",
-          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key. The name must start with a letter, can only contain letters, numbers, and underscores, and must not start with `buildkite` or `bk` (case-insensitive) — names with those prefixes are reserved and the secret will not be created.",
+          "description": "Name of an SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The name must start with a letter, contain only letters, numbers, and underscores, and must not start with `buildkite` or `bk` (case-insensitive).",
           "minLength": 1,
           "maxLength": 255,
-          "pattern": "^(?![Bb][Uu][Ii][Ll][Dd][Kk][Ii][Tt][Ee])(?![Bb][Kk])[A-Za-z][A-Za-z0-9_]*$",
+          "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+          "not": {
+            "pattern": "^([Bb][Uu][Ii][Ll][Dd][Kk][Ii][Tt][Ee]|[Bb][Kk])"
+          },
           "examples": ["deploy_key", "github_readonly", "bitbucket_ssh_key"]
         },
         "lfs": {

--- a/schema.json
+++ b/schema.json
@@ -230,10 +230,10 @@
         },
         "ssh_secret": {
           "type": "string",
-          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key. The name can only contain letters, numbers, and underscores, and must not start with `buildkite` or `bk` (case-insensitive) — names with those prefixes are reserved and the secret will not be created.",
+          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key. The name must start with a letter, can only contain letters, numbers, and underscores, and must not start with `buildkite` or `bk` (case-insensitive) — names with those prefixes are reserved and the secret will not be created.",
           "minLength": 1,
           "maxLength": 255,
-          "pattern": "^(?![Bb][Uu][Ii][Ll][Dd][Kk][Ii][Tt][Ee])(?![Bb][Kk])[A-Za-z0-9_]+$",
+          "pattern": "^(?![Bb][Uu][Ii][Ll][Dd][Kk][Ii][Tt][Ee])(?![Bb][Kk])[A-Za-z][A-Za-z0-9_]*$",
           "examples": ["deploy_key", "github_readonly", "bitbucket_ssh_key"]
         }
       },

--- a/schema.json
+++ b/schema.json
@@ -227,6 +227,12 @@
             { "fetch": "--prune --tags" },
             { "clone": "", "fetch": "" }
           ]
+        },
+        "ssh_secret": {
+          "type": "string",
+          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key. The key will be written to a temporary file with 0400 permissions and removed after checkout completes.",
+          "minLength": 1,
+          "examples": ["deploy-key", "github-readonly", "bitbucket-ssh-key"]
         }
       },
       "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -230,7 +230,7 @@
         },
         "ssh_secret": {
           "type": "string",
-          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key. The key will be written to a temporary file with 0400 permissions and removed after checkout completes.",
+          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key.",
           "minLength": 1,
           "examples": ["deploy-key", "github-readonly", "bitbucket-ssh-key"]
         }

--- a/schema.json
+++ b/schema.json
@@ -230,9 +230,11 @@
         },
         "ssh_secret": {
           "type": "string",
-          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key.",
+          "description": "Name of SSH private key secret from Buildkite Secrets to use for git clone/fetch operations. The secret must contain a valid SSH private key. The name can only contain letters, numbers, and underscores, and must not start with `buildkite` or `bk` (case-insensitive) — names with those prefixes are reserved and the secret will not be created.",
           "minLength": 1,
-          "examples": ["deploy-key", "github-readonly", "bitbucket-ssh-key"]
+          "maxLength": 255,
+          "pattern": "^(?![Bb][Uu][Ii][Ll][Dd][Kk][Ii][Tt][Ee])(?![Bb][Kk])[A-Za-z0-9_]+$",
+          "examples": ["deploy_key", "github_readonly", "bitbucket_ssh_key"]
         }
       },
       "additionalProperties": false

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -501,6 +501,24 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should reject checkout.ssh_secret with a non-string value", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: 123 } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should validate checkout.ssh_secret examples against the schema", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const sshSecretSchema = schema.definitions.checkout.properties.ssh_secret;
+    const v = ajv.compile(sshSecretSchema);
+    for (const example of sshSecretSchema.examples) {
+      expect(v(example), JSON.stringify(example)).to.eql(true);
+    }
+  });
+
   it("should accept checkout.commit_verification with 'strict'", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -737,4 +737,25 @@ describe("schema.json", function () {
       "#/definitions/groupStep",
     );
   });
+
+  // Buildkite's schema checker uses Go's regexp (RE2), which rejects lookaround.
+  // ajv (used here) accepts it, so guard against reintroducing patterns RE2 can't compile.
+  it("should not use regex lookaround in any pattern", function () {
+    const lookaround = /\(\?(=|!|<=|<!)/;
+    const offending = [];
+    const walk = (node) => {
+      if (Array.isArray(node)) {
+        node.forEach(walk);
+      } else if (node && typeof node === "object") {
+        for (const [key, value] of Object.entries(node)) {
+          if (key === "pattern" && typeof value === "string") {
+            if (lookaround.test(value)) offending.push(value);
+          }
+          walk(value);
+        }
+      }
+    };
+    walk(schema);
+    expect(offending).to.eql([]);
+  });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -233,7 +233,7 @@ describe("schema.json", function () {
     const v = ajv.compile(schema);
     const pipeline = {
       steps: [
-        { command: "echo hello", checkout: { ssh_secret: "github-readonly" } },
+        { command: "echo hello", checkout: { ssh_secret: "github_readonly" } },
       ],
     };
     expect(v(pipeline)).to.eql(true);
@@ -255,21 +255,134 @@ describe("schema.json", function () {
       steps: [
         {
           command: "echo hello",
-          checkout: { ssh_secret: "github-readonly", depth: 10 },
+          checkout: { ssh_secret: "github_readonly", depth: 10 },
         },
       ],
     };
     expect(v(pipeline)).to.eql(true);
   });
 
-  it("should validate special characters in checkout.ssh_secret", function () {
+  it("should accept checkout.ssh_secret with underscores", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "my_ssh_key_123" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject checkout.ssh_secret containing dashes", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "deploy-key" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret containing dots", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "deploy.key" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret containing spaces", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "deploy key" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with 'buildkite'", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "buildkite_key" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with 'BUILDKITE' (uppercase)", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "BUILDKITE_KEY" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with 'Buildkite' (mixed case)", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "Buildkite_thing" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with 'bk'", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: "bk_key" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with 'BK' (uppercase)", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: "BK_secret" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with 'Bk' (mixed case)", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: "Bk_thing" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.ssh_secret containing 'bk' not as a prefix", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: "my_bk_key" } }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should accept checkout.ssh_secret containing 'buildkite' not as a prefix", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
     const pipeline = {
       steps: [
         {
           command: "echo hello",
-          checkout: { ssh_secret: "my-secret_with.special-characters" },
+          checkout: { ssh_secret: "my_buildkite_thing" },
         },
       ],
     };

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -399,17 +399,6 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(true);
   });
 
-  it("should reject numeric names in checkout.ssh_secret", function () {
-    const ajv = new Ajv({ allErrors: true });
-    const v = ajv.compile(schema);
-    const pipeline = {
-      steps: [
-        { command: "echo hello", checkout: { ssh_secret: "1234567890" } },
-      ],
-    };
-    expect(v(pipeline)).to.eql(false);
-  });
-
   it("should reject checkout.ssh_secret starting with a digit", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -228,6 +228,76 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(false);
   });
 
+  it("should accept checkout.ssh_secret", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "github-readonly" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject checkout.ssh_secret with an empty string", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: "" } }],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.ssh_secret with other checkout properties", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { ssh_secret: "github-readonly", depth: 10 },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should validate special characters in checkout.ssh_secret", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        {
+          command: "echo hello",
+          checkout: { ssh_secret: "my-secret_with.special-characters" },
+        },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should validate numeric names in checkout.ssh_secret", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "1234567890" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should validate very long names in checkout.ssh_secret", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "a".repeat(255) } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
   it("should accept checkout.commit_verification with 'strict'", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -239,6 +239,16 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(true);
   });
 
+  it("should accept pipeline-level checkout.ssh_secret", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      checkout: { ssh_secret: "github_readonly" },
+      steps: [{ command: "echo hello" }],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
   it("should reject checkout.ssh_secret with an empty string", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
@@ -389,7 +399,7 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(true);
   });
 
-  it("should validate numeric names in checkout.ssh_secret", function () {
+  it("should reject numeric names in checkout.ssh_secret", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
     const pipeline = {
@@ -397,10 +407,41 @@ describe("schema.json", function () {
         { command: "echo hello", checkout: { ssh_secret: "1234567890" } },
       ],
     };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with a digit", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "1deploy_key" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject checkout.ssh_secret starting with an underscore", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "_deploy_key" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept checkout.ssh_secret with digits after the leading letter", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [{ command: "echo hello", checkout: { ssh_secret: "key_2024" } }],
+    };
     expect(v(pipeline)).to.eql(true);
   });
 
-  it("should validate very long names in checkout.ssh_secret", function () {
+  it("should accept checkout.ssh_secret at the 255-character maxLength", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);
     const pipeline = {
@@ -409,6 +450,17 @@ describe("schema.json", function () {
       ],
     };
     expect(v(pipeline)).to.eql(true);
+  });
+
+  it("should reject checkout.ssh_secret exceeding the 255-character maxLength", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { ssh_secret: "a".repeat(256) } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(false);
   });
 
   it("should accept checkout.commit_verification with 'strict'", function () {

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -7,6 +7,7 @@ checkout:
     fetch: "--prune --tags"
     checkout: "--force"
     clean: "-fxd"
+  ssh_secret: "github_readonly"
 
 steps:
   - command: test

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -33,13 +33,13 @@ steps:
   - command: test
     checkout:
       skip: false
-      commit_verification: "strict" 
+      commit_verification: "strict"
 
   - command: test
     checkout:
       depth: 10
       commit_verification: "strict"
-      ssh_secret: "github-readonly"
+      ssh_secret: "github_readonly"
 
   - command: test
     checkout:
@@ -49,4 +49,4 @@ steps:
 
   - command: test
     checkout:
-      ssh_secret: "github-readonly"
+      ssh_secret: "github_readonly"

--- a/test/valid-pipelines/checkout.yml
+++ b/test/valid-pipelines/checkout.yml
@@ -33,15 +33,20 @@ steps:
   - command: test
     checkout:
       skip: false
-      commit_verification: "strict"
+      commit_verification: "strict" 
 
   - command: test
     checkout:
       depth: 10
       commit_verification: "strict"
+      ssh_secret: "github-readonly"
 
   - command: test
     checkout:
       flags:
         clone: "--depth 1"
         clean: ""
+
+  - command: test
+    checkout:
+      ssh_secret: "github-readonly"


### PR DESCRIPTION
- Add `ssh_secret`  property under the `checkout` definition
- Add tests to validate name and reject an empty `ssh_secret` name
- Add examples in `test/valid-pipelines/checkout.yml`