### PR TITLE
Add if and structured fields to notifyGithubCheck

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -338,7 +338,80 @@
       "type": "object",
       "properties": {
         "github_check": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of the GitHub check",
+              "type": "string"
+            },
+            "output": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "description": "The title of the GitHub check's output",
+                  "type": "string"
+                },
+                "summary": {
+                  "description": "The summary of the GitHub check's output",
+                  "type": "string"
+                },
+                "text": {
+                  "description": "The details of the GitHub check's output. Supports Markdown",
+                  "type": "string"
+                },
+                "annotations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "description": "The path of the file to add an annotation to, relative to the repository root",
+                        "type": "string"
+                      },
+                      "start_line": {
+                        "description": "The start line of the annotation",
+                        "type": "integer"
+                      },
+                      "end_line": {
+                        "description": "The end line of the annotation",
+                        "type": "integer"
+                      },
+                      "start_column": {
+                        "description": "The start column of the annotation. Only valid when start_line and end_line are equal",
+                        "type": "integer"
+                      },
+                      "end_column": {
+                        "description": "The end column of the annotation. Only valid when start_line and end_line are equal",
+                        "type": "integer"
+                      },
+                      "annotation_level": {
+                        "type": "string",
+                        "description": "The level of the annotation",
+                        "enum": ["notice", "warning", "failure"]
+                      },
+                      "message": {
+                        "description": "The message for the annotation",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "start_line",
+                      "end_line",
+                      "annotation_level",
+                      "message"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "if": {
+          "$ref": "#/definitions/if"
         }
       },
       "additionalProperties": false

--- a/test/valid-pipelines/notify.yml
+++ b/test/valid-pipelines/notify.yml
@@ -52,6 +52,29 @@ notify:
       context: "my-custom-status"
     if: "build.state == 'failed'"
 
+  - github_check:
+      name: "My Custom Check"
+      output:
+        title: "Test Results"
+        summary: "All tests passed"
+        text: "**All tests passed!**"
+        annotations:
+          - path: "src/main.js"
+            start_line: 15
+            end_line: 15
+            annotation_level: "warning"
+            message: "Missing semicolon"
+          - path: "src/main.js"
+            start_line: 20
+            end_line: 20
+            start_column: 5
+            end_column: 10
+            annotation_level: "failure"
+            message: "Undefined variable"
+  - github_check:
+      name: "My Custom Check"
+    if: "build.state == 'failed'"
+
 steps:
   - command: "blah.sh"
 
@@ -94,4 +117,13 @@ steps:
           context: "my-custom-status"
       - github_commit_status:
           context: "my-custom-status"
+        if: "build.state == 'failed'"
+
+      - github_check:
+          name: "My Custom Check"
+          output:
+            title: "Test Results"
+            summary: "All tests passed"
+      - github_check:
+          name: "My Custom Check"
         if: "build.state == 'failed'"


### PR DESCRIPTION
Found this while digging into a buildkite-sdk bug. The `github_check` was the only notify type that didn't support an `if `field, and its sub-object only allowed `{}`. So valid fields like `if`, `name`, and `output` (title, summary, annotations) were getting rejected by the schema. Added`if` so it matches the other notify types, and expanded `github_check` to support the fields it's actually supposed to.