### PR TITLE
Add if and structured fields to notifyGithubCheck

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -338,7 +338,80 @@
       "type": "object",
       "properties": {
         "github_check": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of the GitHub check",
+              "type": "string"
+            },
+            "output": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "description": "The title of the GitHub check's output",
+                  "type": "string"
+                },
+                "summary": {
+                  "description": "The summary of the GitHub check's output",
+                  "type": "string"
+                },
+                "text": {
+                  "description": "The details of the GitHub check's output. Supports Markdown",
+                  "type": "string"
+                },
+                "annotations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "description": "The path of the file to add an annotation to, relative to the repository root",
+                        "type": "string"
+                      },
+                      "start_line": {
+                        "description": "The start line of the annotation",
+                        "type": "integer"
+                      },
+                      "end_line": {
+                        "description": "The end line of the annotation",
+                        "type": "integer"
+                      },
+                      "start_column": {
+                        "description": "The start column of the annotation. Only valid when start_line and end_line are equal",
+                        "type": "integer"
+                      },
+                      "end_column": {
+                        "description": "The end column of the annotation. Only valid when start_line and end_line are equal",
+                        "type": "integer"
+                      },
+                      "annotation_level": {
+                        "type": "string",
+                        "description": "The level of the annotation",
+                        "enum": ["notice", "warning", "failure"]
+                      },
+                      "message": {
+                        "description": "The message for the annotation",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "start_line",
+                      "end_line",
+                      "annotation_level",
+                      "message"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "if": {
+          "$ref": "#/definitions/if"
         }
       },
       "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -392,6 +392,14 @@
                       "message": {
                         "description": "The message for the annotation",
                         "type": "string"
+                      },
+                      "title": {
+                        "description": "The title for the annotation",
+                        "type": "string"
+                      },
+                      "raw_details": {
+                        "description": "Additional details for the annotation, displayed alongside the message",
+                        "type": "string"
                       }
                     },
                     "required": [

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -199,6 +199,101 @@ describe("schema.json", function() {
     expect(v(pipeline)).to.eql(true);
   });
 
+  it("should reject a github_check with an unknown property", function() {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello" }
+      ],
+      notify: [
+        { github_check: { foo: "bar" } }
+      ]
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject a github_check output with an unknown property", function() {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello" }
+      ],
+      notify: [
+        { github_check: { output: { bogus_field: "x" } } }
+      ]
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject a github_check annotation with an invalid annotation_level", function() {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello" }
+      ],
+      notify: [
+        {
+          github_check: {
+            output: {
+              annotations: [
+                {
+                  path: "src/main.js",
+                  start_line: 1,
+                  end_line: 1,
+                  annotation_level: "critical",
+                  message: "bad level"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should reject a github_check annotation missing required fields", function() {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello" }
+      ],
+      notify: [
+        {
+          github_check: {
+            output: {
+              annotations: [
+                { path: "src/main.js" }
+              ]
+            }
+          }
+        }
+      ]
+    };
+    expect(v(pipeline)).to.eql(false);
+  });
+
+  it("should accept a valid github_check with if", function() {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello" }
+      ],
+      notify: [
+        {
+          github_check: { name: "My Check" },
+          if: "build.state == 'failed'"
+        }
+      ]
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
   it("should verify groupStep.steps uses the same-ish items as root steps", function() {
     const mainList = schema.definitions.pipelineSteps.items.anyOf;
     const groupList = schema.definitions.groupSteps.items.anyOf;

--- a/test/valid-pipelines/notify.yml
+++ b/test/valid-pipelines/notify.yml
@@ -124,6 +124,20 @@ steps:
           output:
             title: "Test Results"
             summary: "All tests passed"
+            text: "**All tests passed!**"
+            annotations:
+              - path: "src/main.js"
+                start_line: 15
+                end_line: 15
+                annotation_level: "warning"
+                message: "Missing semicolon"
+              - path: "src/main.js"
+                start_line: 20
+                end_line: 20
+                start_column: 5
+                end_column: 10
+                annotation_level: "failure"
+                message: "Undefined variable"
       - github_check:
           name: "My Custom Check"
         if: "build.state == 'failed'"

--- a/test/valid-pipelines/notify.yml
+++ b/test/valid-pipelines/notify.yml
@@ -52,6 +52,29 @@ notify:
       context: "my-custom-status"
     if: "build.state == 'failed'"
 
+  - github_check:
+      name: "My Custom Check"
+      output:
+        title: "Test Results"
+        summary: "All tests passed"
+        text: "**All tests passed!**"
+        annotations:
+          - path: "src/main.js"
+            start_line: 15
+            end_line: 15
+            annotation_level: "warning"
+            message: "Missing semicolon"
+          - path: "src/main.js"
+            start_line: 20
+            end_line: 20
+            start_column: 5
+            end_column: 10
+            annotation_level: "failure"
+            message: "Undefined variable"
+  - github_check:
+      name: "My Custom Check"
+    if: "build.state == 'failed'"
+
 steps:
   - command: "blah.sh"
 
@@ -94,4 +117,13 @@ steps:
           context: "my-custom-status"
       - github_commit_status:
           context: "my-custom-status"
+        if: "build.state == 'failed'"
+
+      - github_check:
+          name: "My Custom Check"
+          output:
+            title: "Test Results"
+            summary: "All tests passed"
+      - github_check:
+          name: "My Custom Check"
         if: "build.state == 'failed'"

--- a/test/valid-pipelines/notify.yml
+++ b/test/valid-pipelines/notify.yml
@@ -71,6 +71,8 @@ notify:
             end_column: 10
             annotation_level: "failure"
             message: "Undefined variable"
+            title: "Syntax error"
+            raw_details: "ReferenceError: foo is not defined"
   - github_check:
       name: "My Custom Check"
     if: "build.state == 'failed'"


### PR DESCRIPTION
Found this while digging into a buildkite-sdk bug. The github_check was the only notify type that didn't support an `if `field, and its sub-object only allowed `{}`. So valid fields like `if`, `name`, and `output` (title, summary, annotations) were getting rejected by the schema. Added `if` so it matches the other notify types, and expanded `github_check` to support the fields it's actually supposed to.