### PR TITLE
Allow commit verification off in pipeline schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -195,8 +195,8 @@
         },
         "commit_verification": {
           "type": "string",
-          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive mismatch, warn only logs",
-          "enum": ["strict", "warn"]
+          "description": "Verify the checked-out commit is on the expected branch; strict fails the job on a definitive mismatch, warn only logs (Agent v3 only), and off disables verification (Agent v4 only)",
+          "enum": ["strict", "warn", "off"]
         },
         "flags": {
           "type": "object",

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -611,6 +611,17 @@ describe("schema.json", function () {
     expect(v(pipeline)).to.eql(true);
   });
 
+  it("should accept checkout.commit_verification with 'off'", function () {
+    const ajv = new Ajv({ allErrors: true });
+    const v = ajv.compile(schema);
+    const pipeline = {
+      steps: [
+        { command: "echo hello", checkout: { commit_verification: "off" } },
+      ],
+    };
+    expect(v(pipeline)).to.eql(true);
+  });
+
   it("should reject checkout.commit_verification with an invalid string value", function () {
     const ajv = new Ajv({ allErrors: true });
     const v = ajv.compile(schema);


### PR DESCRIPTION
## Why

Agent v3 supports `strict` and `warn` for commit verification, while Agent v4 supports `strict` and `off`. The schema currently accepts only the v3 values, which prevents v4 users from selecting `off`.

Related: [SUP-8017](https://linear.app/buildkite/issue/SUP-8017)

## What

Allow `strict`, `warn`, and `off`, with the schema description noting that `warn` is v3-only and `off` is v4-only. The agent remains responsible for validating whether it supports the selected value.

Deploy this after the corresponding change to bkbk.